### PR TITLE
Add race condition tests to dendrite unit tests

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -35,14 +35,14 @@ steps:
           limit: 3
 
   - command:
-    - "go test ./..."
+    - "go test -race ./..."
     label: "\U0001F9EA Unit tests / :go: 1.11"
     plugins:
       - docker#v3.0.1:
           image: "golang:1.11"
 
   - command:
-    - "go test ./..."
+    - "go test -race ./..."
     label: "\U0001F9EA Unit tests / :go: 1.12"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
cc @cnly 

Enables the race condition checker when running Dendrite's unit tests.

The other half of this PR (that enables the checks on Sytest) is here: https://github.com/matrix-org/dendrite/pull/745/ Though currently this makes sytest runs quite slow, so whether we want to merge that before fixing the races is questionable.

I don't consider this PR blocked on that one.