### PR TITLE
Add annotation uploading to dendrite

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -80,6 +80,9 @@ steps:
           volumes: ["./logs:/logs"]
       - artifacts#v1.2.0:
           upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
+      - matrix-org/annotate:
+          path: "logs/annotate.md"
+          style: "error"
     soft_fail:
       - exit_status: 1
     retry:


### PR DESCRIPTION
Will add a nice display to Dendrite's Sytest results similar to what Synapse currently has:

![image](https://user-images.githubusercontent.com/1342360/66148498-f8372080-e608-11e9-9f61-be351b764fe3.png)

~~Blocked on having an `annotate.md` file generated by the Dendrite sytest script.~~ (A Perl implementation is provided by https://github.com/matrix-org/sytest/pull/714).

Here is where Synapse's is generated: https://github.com/matrix-org/sytest/blob/f686445b98d375a1f060bd8e2775b05656b18193/docker/synapse_sytest.sh#L89-L92