### PR TITLE
Add CI jobs for synapse_port_db

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -332,7 +332,7 @@ steps:
       TRIAL_FLAGS: "-j 8"
     command:
       - "python -m pip install tox"
-      - "tox -e synapse_port_db"
+      - "bash .buildkite/scripts/test_synapse_port_db.sh"
     plugins:
       - docker-compose#v2.1.0:
           run: testenv
@@ -357,7 +357,7 @@ steps:
       TRIAL_FLAGS: "-j 8"
     command:
       - "python -m pip install tox"
-      - "tox -e synapse_port_db"
+      - "bash .buildkite/scripts/test_synapse_port_db.sh"
     plugins:
       - docker-compose#v2.1.0:
           run: testenv

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -329,7 +329,6 @@ steps:
     agents:
       queue: "medium"
     command:
-      - "python -m pip install tox"
       - "bash .buildkite/scripts/test_synapse_port_db.sh"
     plugins:
       - docker-compose#v2.1.0:
@@ -346,7 +345,6 @@ steps:
     agents:
       queue: "medium"
     command:
-      - "python -m pip install tox"
       - "bash .buildkite/scripts/test_synapse_port_db.sh"
     plugins:
       - docker-compose#v2.1.0:

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -340,7 +340,6 @@ steps:
 #      - matrix-org/coveralls#v1.0:
 #          parallel: "true"
 
-
   - label: "synapse_port_db / :python: 3.7 / :postgres: 11"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -325,6 +325,56 @@ steps:
         - exit_status: 2
           limit: 2
 
+  - label: "synapse_port_db / :python: 3.5 / :postgres: 9.5"
+    agents:
+      queue: "medium"
+    env:
+      TRIAL_FLAGS: "-j 8"
+    command:
+      - "python -m pip install tox"
+      - "tox -e synapse_port_db"
+    plugins:
+      - docker-compose#v2.1.0:
+          run: testenv
+          config:
+            - .buildkite/docker-compose.py35.pg95.yaml
+      - artifacts#v1.2.0:
+          upload: [ "_trial_temp/*/*.log" ]
+#      - matrix-org/coveralls#v1.0:
+#          parallel: "true"
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+
+  - label: "synapse_port_db / :python: 3.7 / :postgres: 11"
+    agents:
+      queue: "medium"
+    env:
+      TRIAL_FLAGS: "-j 8"
+    command:
+      - "python -m pip install tox"
+      - "tox -e synapse_port_db"
+    plugins:
+      - docker-compose#v2.1.0:
+          run: testenv
+          config:
+            - .buildkite/docker-compose.py37.pg11.yaml
+      - artifacts#v1.2.0:
+          upload: [ "_trial_temp/*/*.log" ]
+#      - matrix-org/coveralls#v1.0:
+#          parallel: "true"
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+
 #  - wait: ~
 #    continue_on_failure: true
 #

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -353,8 +353,6 @@ steps:
   - label: "synapse_port_db / :python: 3.7 / :postgres: 11"
     agents:
       queue: "medium"
-    env:
-      TRIAL_FLAGS: "-j 8"
     command:
       - "python -m pip install tox"
       - "bash .buildkite/scripts/test_synapse_port_db.sh"
@@ -367,13 +365,6 @@ steps:
           upload: [ "_trial_temp/*/*.log" ]
 #      - matrix-org/coveralls#v1.0:
 #          parallel: "true"
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-        - exit_status: 2
-          limit: 2
-
 
 #  - wait: ~
 #    continue_on_failure: true

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -328,8 +328,6 @@ steps:
   - label: "synapse_port_db / :python: 3.5 / :postgres: 9.5"
     agents:
       queue: "medium"
-    env:
-      TRIAL_FLAGS: "-j 8"
     command:
       - "python -m pip install tox"
       - "bash .buildkite/scripts/test_synapse_port_db.sh"
@@ -342,12 +340,6 @@ steps:
           upload: [ "_trial_temp/*/*.log" ]
 #      - matrix-org/coveralls#v1.0:
 #          parallel: "true"
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-        - exit_status: 2
-          limit: 2
 
 
   - label: "synapse_port_db / :python: 3.7 / :postgres: 11"


### PR DESCRIPTION
Paired with https://github.com/matrix-org/synapse/pull/6140

Defines the Synapse CI jobs to run the tox environment added in https://github.com/matrix-org/synapse/pull/6140