### PR TITLE
Prevent soft-failing on Dendrite's Sytest runs

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -80,8 +80,6 @@ steps:
           volumes: ["./logs:/logs"]
       - artifacts#v1.2.0:
           upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
-    soft_fail:
-      - exit_status: 1
     retry:
       automatic:
         - exit_status: -1


### PR DESCRIPTION
Sytest used to be broken, now it is not!

Turn off soft-failing so I don't keep missing PRs failing Sytest and then merging them.