### PR TITLE
Have sytest CI use same-named branch of Synapse/Dendrite if exists, else use the dev branch

### DIFF
--- a/sytest/pipeline.yml
+++ b/sytest/pipeline.yml
@@ -4,7 +4,7 @@ steps:
       queue: "medium"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash /bootstrap.sh synapse"
     plugins:
@@ -37,7 +37,7 @@ steps:
       POSTGRES: "1"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash /bootstrap.sh synapse"
     plugins:
@@ -72,7 +72,7 @@ steps:
       BLACKLIST: "synapse-blacklist-with-workers"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash -c 'cat /src/sytest-blacklist /src/.buildkite/worker-blacklist > /src/synapse-blacklist-with-workers'"
       - "bash /bootstrap.sh synapse"
@@ -106,7 +106,7 @@ steps:
       POSTGRES: "1"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash /bootstrap.sh synapse"
     plugins:
@@ -141,7 +141,7 @@ steps:
       BLACKLIST: "synapse-blacklist-with-workers"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash -c 'cat /src/sytest-blacklist /src/.buildkite/worker-blacklist > /src/synapse-blacklist-with-workers'"
       - "bash /bootstrap.sh synapse"
@@ -175,7 +175,7 @@ steps:
       POSTGRES: "1"
     command:
       - "mkdir -p /src"
-      - "wget -O - https://github.com/matrix-org/dendrite/archive/master.tar.gz | tar -xz --strip-components=1 -C /src/"
+      - "(wget -O - https://github.com/matrix-org/dendrite/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/dendrite/archive/master.tar.gz) | tar -xz --strip-components=1 -C /src/"
       - "cd /src/"
       - "bash /bootstrap.sh dendrite"
     plugins:


### PR DESCRIPTION
It annoys me that sytest runs keep failing because they're using Synapse develop instead of the branch their intended to pair with. Hopefully this'll also prevent some accidental bugs in the future.