### PR TITLE
Run worker sytests with split out databases

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -305,6 +305,7 @@ steps:
     agents:
       queue: "medium"
     env:
+      MULTI_POSTGRES: "1"  # Test with split out databases
       POSTGRES: "1"
       WORKERS: "1"
       BLACKLIST: "synapse-blacklist-with-workers"
@@ -375,6 +376,7 @@ steps:
     agents:
       queue: "medium"
     env:
+      MULTI_POSTGRES: "1"  # Test with split out databases
       POSTGRES: "1"
       WORKERS: "1"
       BLACKLIST: "synapse-blacklist-with-workers"


### PR DESCRIPTION
Enables the feature added in https://github.com/matrix-org/sytest/pull/775, but should be backwards compat as we still specify `POSTGRES` env var