### PR TITLE
We use yarn now for bifrost

### DIFF
--- a/matrix-bifrost/pipeline.yml
+++ b/matrix-bifrost/pipeline.yml
@@ -1,26 +1,26 @@
 steps:
   - label: ":eslint: Lint"
     command:
-      - "npm install"
-      - "npm run lint"
+      - "yarn install"
+      - "yarn lint"
     plugins:
       - docker#v3.0.1:
           image: "node:12"
 
   - label: ":nodejs: 10 :mocha: Unit/Integration Test"
     command:
-      - "npm install"
-      - "npm run build"
-      - "npm run test"
+      - "yarn install"
+      - "yarn build"
+      - "yarn test"
     plugins:
       - docker#v3.0.1:
           image: "node:10"
 
   - label: ":nodejs: 12 :mocha: Unit/Integration Test"
     command:
-      - "npm install"
-      - "npm run build"
-      - "npm run test"
+      - "yarn install"
+      - "yarn build"
+      - "yarn test"
     plugins:
       - docker#v3.0.1:
           image: "node:12"


### PR DESCRIPTION
we use yarn for bifrost now, which means if we try to CI with npm then we won't use the yarn.lock file, which isn't a great test