### PR TITLE
Run linter under go 1.13, try building dendrite under go 1.13

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -3,13 +3,13 @@ steps:
       - "env"
       # https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
       - "GOGC=20 ./scripts/find-lint.sh"
-    label: "\U0001F9F9 Lint / :go: 1.12"
+    label: "\U0001F9F9 Lint / :go: 1.13"
     agents:
       # Use a larger instance as linting takes a looot of memory
       queue: "medium"
     plugins:
       - docker#v3.0.1:
-          image: "golang:1.12"
+          image: "golang:1.13"
           mount-buildkite-agent: false
 
   - wait
@@ -39,6 +39,19 @@ steps:
       automatic:
         - exit_status: 128
           limit: 3
+          
+  - command:
+      - "env"
+      - "go build ./cmd/..."
+    label: "\U0001F528 Build / :go: 1.13"
+    plugins:
+      - docker#v3.0.1:
+          image: "golang:1.13"
+          mount-buildkite-agent: false
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3
 
   - command:
       - "env"
@@ -56,6 +69,15 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "golang:1.12"
+          mount-buildkite-agent: false
+          
+  - command:
+      - "env"
+      - "go test ./..."
+    label: "\U0001F9EA Unit tests / :go: 1.13"
+    plugins:
+      - docker#v3.0.1:
+          image: "golang:1.13"
           mount-buildkite-agent: false
 
   - label: "SyTest - :go: 1.11 / :postgres: 9.6"


### PR DESCRIPTION
Running the linter under Go 1.13 should hopefully fix the panics (like in https://github.com/golangci/golangci-lint/issues/732). It also checks that Dendrite successfully builds and runs unit tests under Go 1.13 too.