### PR TITLE
Add jobs for Python 3 for Sydent

### DIFF
--- a/sydent/pipeline.yml
+++ b/sydent/pipeline.yml
@@ -2,9 +2,9 @@ steps:
   - command:
       - "echo '--- Install dependencies'"
       - "pip install -e ."
-      - "echo '--- Run unit tests'"
+      - "echo '+++ Run unit tests'"
       - "trial tests"
-    label: ":partyparrot: Unit tests"
+    label: ":partyparrot: Unit tests / :python: 2.7"
     plugins:
       - docker#v3.0.1:
           image: "python:2.7"
@@ -18,7 +18,7 @@ steps:
       - "pip install git+https://github.com/matrix-org/matrix-is-tester.git"
       - "echo '+++ Run Tests'"
       - "trial matrix_is_tester"
-    label: ":pytest: matrix_is_tester"
+    label: ":pytest: matrix_is_tester / :python: 2.7"
     timeout_in_minutes: 5
     plugins:
       - docker#v3.0.1:
@@ -26,3 +26,75 @@ steps:
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"
+
+  - command:
+      - "echo '--- Install dependencies'"
+      - "pip install -e ."
+      - "echo '+++ Run unit tests'"
+      - "trial tests"
+    label: ":partyparrot: Unit tests / :python: 3.5"
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.5"
+    artifact_paths:
+      - "_trial_temp/test.log"
+    # The Python 3 compatibility PRs aren't all merged yet so this will
+    # fail until that happens.
+    soft_fail:
+      - exit_status: 1
+
+  - command:
+      - "echo '--- Install dependencies'"
+      - "pip install -e ."
+      - "echo '--- Install matrix_is_tester'"
+      - "pip install git+https://github.com/matrix-org/matrix-is-tester.git"
+      - "echo '+++ Run Tests'"
+      - "trial matrix_is_tester"
+    label: ":pytest: matrix_is_tester / :python: 3.5"
+    timeout_in_minutes: 5
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.5"
+    artifact_paths:
+      - "matrix_is_test/sydent.stderr"
+      - "_trial_temp/test.log"
+    # The Python 3 compatibility PRs aren't all merged yet so this will
+    # fail until that happens.
+    soft_fail:
+      - exit_status: 1
+
+  - command:
+      - "echo '--- Install dependencies'"
+      - "pip install -e ."
+      - "echo '+++ Run unit tests'"
+      - "trial tests"
+    label: ":partyparrot: Unit tests / :python: 3.8"
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.8"
+    artifact_paths:
+      - "_trial_temp/test.log"
+    # The Python 3 compatibility PRs aren't all merged yet so this will
+    # fail until that happens.
+    soft_fail:
+      - exit_status: 1
+
+  - command:
+      - "echo '--- Install dependencies'"
+      - "pip install -e ."
+      - "echo '--- Install matrix_is_tester'"
+      - "pip install git+https://github.com/matrix-org/matrix-is-tester.git"
+      - "echo '+++ Run Tests'"
+      - "trial matrix_is_tester"
+    label: ":pytest: matrix_is_tester / :python: 3.8"
+    timeout_in_minutes: 5
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.8"
+    artifact_paths:
+      - "matrix_is_test/sydent.stderr"
+      - "_trial_temp/test.log"
+    # The Python 3 compatibility PRs aren't all merged yet so this will
+    # fail until that happens.
+    soft_fail:
+      - exit_status: 1


### PR DESCRIPTION
Add CI jobs for testing Python 3 for Sydent. These jobs are soft-failed, since these jobs will fail until all of [the Python 3 compatibility PRs](https://github.com/matrix-org/sydent/pulls?utf8=%E2%9C%93&q=is%3Apr+label%3Apy3) are merged.