### PR TITLE
Don't soft fail Python 3 failures anymore

### DIFF
--- a/sydent/pipeline.yml
+++ b/sydent/pipeline.yml
@@ -38,10 +38,6 @@ steps:
           image: "python:3.5"
     artifact_paths:
       - "_trial_temp/test.log"
-    # The Python 3 compatibility PRs aren't all merged yet so this will
-    # fail until that happens.
-    soft_fail:
-      - exit_status: 1
 
   - command:
       - "echo '--- Install dependencies'"
@@ -58,10 +54,6 @@ steps:
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"
-    # The Python 3 compatibility PRs aren't all merged yet so this will
-    # fail until that happens.
-    soft_fail:
-      - exit_status: 1
 
   - command:
       - "echo '--- Install dependencies'"
@@ -74,10 +66,6 @@ steps:
           image: "python:3.8"
     artifact_paths:
       - "_trial_temp/test.log"
-    # The Python 3 compatibility PRs aren't all merged yet so this will
-    # fail until that happens.
-    soft_fail:
-      - exit_status: 1
 
   - command:
       - "echo '--- Install dependencies'"
@@ -94,7 +82,3 @@ steps:
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"
-    # The Python 3 compatibility PRs aren't all merged yet so this will
-    # fail until that happens.
-    soft_fail:
-      - exit_status: 1


### PR DESCRIPTION
Revival of https://github.com/matrix-org/pipelines/pull/34, depends on https://github.com/matrix-org/sydent/pull/266