### PR TITLE
Run long CI steps lint, sytest in parallel

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -1,21 +1,6 @@
 steps:
   - command:
       - "env"
-      # https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-      - "GOGC=20 ./scripts/find-lint.sh"
-    label: "\U0001F9F9 Lint / :go: 1.13"
-    agents:
-      # Use a larger instance as linting takes a looot of memory
-      queue: "medium"
-    plugins:
-      - docker#v3.0.1:
-          image: "golang:1.13"
-          mount-buildkite-agent: false
-
-  - wait
-          
-  - command:
-      - "env"
       - "go build ./cmd/..."
     label: "\U0001F528 Build / :go: 1.13"
     plugins:
@@ -36,6 +21,21 @@ steps:
           image: "golang:1.13"
           mount-buildkite-agent: false
 
+  - wait
+
+  - command:
+      - "env"
+      # https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
+      - "GOGC=20 ./scripts/find-lint.sh"
+    label: "\U0001F9F9 Lint / :go: 1.13"
+    agents:
+      # Use a larger instance as linting takes a looot of memory
+      queue: "medium"
+    plugins:
+      - docker#v3.0.1:
+          image: "golang:1.13"
+          mount-buildkite-agent: false
+          
   - label: "SyTest - :go: 1.13 / :postgres: 9.6"
     agents:
       queue: "medium"


### PR DESCRIPTION
Linting takes quite a while, and so does running the sytests. The overall CI pipeline would be faster if these steps were run in parallel.

Conversely though, we don't want to run them and gum up CI if your code doesn't even build. So run that step initially, along with unit tests as both are very quick.

To be clear, this changes the pipline from:

- Lint
- -- wait --
- Build
- Unit Tests
- SyTests

to

- Build
- Unit Tests
- -- wait --
- Lint
- SyTests