### PR TITLE
Fix postgres tests for IRC bridge

### DIFF
--- a/matrix-appservice-irc/docker-compose.postgres.yml
+++ b/matrix-appservice-irc/docker-compose.postgres.yml
@@ -17,5 +17,4 @@ services:
       IRCBRIDGE_TEST_ENABLEPG: "yes"
     working_dir: /app
     volumes:
-      - ..:/app
-    command: "bash -c 'yarn && yarn test'"
+      - ${BUILDKITE_BUILD_CHECKOUT_PATH}:/app

--- a/matrix-appservice-irc/pipeline.yml
+++ b/matrix-appservice-irc/pipeline.yml
@@ -28,8 +28,7 @@ steps:
 
   - label: ":nodejs: 12 :postgres: 11 :jasmine: Postgres Test"
     command:
-      - "yarn"
-      - "yarn test"
+      - "/bin/sh -c 'yarn && yarn ci-test'"
     plugins:
       - matrix-org/download#v1.1.0:
           urls:

--- a/matrix-appservice-irc/pipeline.yml
+++ b/matrix-appservice-irc/pipeline.yml
@@ -28,7 +28,8 @@ steps:
 
   - label: ":nodejs: 12 :postgres: 11 :jasmine: Postgres Test"
     command:
-      - "/bin/sh -c 'yarn && yarn ci-test'"
+      - yarn
+      - yarn ci-test
     plugins:
       - matrix-org/download#v1.1.0:
           urls:

--- a/matrix-appservice-irc/pipeline.yml
+++ b/matrix-appservice-irc/pipeline.yml
@@ -27,6 +27,9 @@ steps:
           mount-buildkite-agent: false
 
   - label: ":nodejs: 12 :postgres: 11 :jasmine: Postgres Test"
+    command:
+      - "yarn"
+      - "yarn test"
     plugins:
       - matrix-org/download#v1.1.0:
           urls:


### PR DESCRIPTION
It didn't like the way we were doing it. I've tried to copy how synapse runs these tests.

I've tried to verify this approach works by doing `
BUILDKITE_BUILD_CHECKOUT_PATH=/home/will/git/matrix-appservice-irc/
docker-compose -f /home/will/git/pipelines/docker-compose.postgres.yml run testenv /bin/sh -c 'yarn && yarn ci-test'`

which worked fine.