### PR TITLE
Initial pipelines for riot-web

### DIFF
--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -29,7 +29,7 @@ steps:
           image: "node:12"
           mount-buildkite-agent: false
 
-  - label: "🛠 Build"
+  - label: ":hammer_and_pick: Build"
     command:
       - "echo '--- Fetching Dependencies'"
       - "./scripts/fetch-develop.deps.sh --depth 1"
@@ -58,7 +58,7 @@ steps:
           image: "node:10"
           mount-buildkite-agent: false
 
-  - label: "🌐 i18n"
+  - label: ":globe_with_meridians: i18n"
     command:
       - "echo '--- Fetching Dependencies'"
       - "./scripts/fetch-develop.deps.sh --depth 1"

--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -1,0 +1,91 @@
+steps:
+  - label: ":eslint: JS Lint"
+    command:
+      - "echo '--- Fetching Dependencies'"
+      - "./scripts/fetch-develop.deps.sh --depth 1"
+      - "yarn install"
+      - "yarn lint:js"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+          mount-buildkite-agent: false
+
+# This layer doesn't have a TypeScript linter. This comment is to remind TravisR to fix that.
+#  - label: ":eslint: TS Lint"
+#    command:
+#      - "echo '--- Install js-sdk'"
+#      - "./scripts/ci/install-deps.sh"
+#      - "yarn lint:ts"
+#    plugins:
+#      - docker#v3.0.1:
+#          image: "node:12"
+
+  - label: ":eslint: Types Lint"
+    command:
+      - "yarn install"
+      - "yarn lint:types"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+          mount-buildkite-agent: false
+
+  - label: "🛠 Build"
+    command:
+      - "echo '--- Fetching Dependencies'"
+      - "./scripts/fetch-develop.deps.sh --depth 1"
+      - "yarn install"
+      - "echo '+++ Building Project'"
+      - "yarn build"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+          mount-buildkite-agent: false
+
+  - label: ":jest: Tests"
+    agents:
+      # We use a medium sized instance instead of the normal small ones because
+      # webpack loves to gorge itself on resources.
+      queue: "medium"
+    command:
+      - "echo '--- Fetching Dependencies'"
+      - "./scripts/fetch-develop.deps.sh --depth 1"
+      - "yarn install"
+      - "yarn build:genfiles"  # We have to build the app to make sure the autogenned files are present
+      - "echo '+++ Running Tests'"
+      - "yarn test"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:10"
+          mount-buildkite-agent: false
+
+  - label: "🌐 i18n"
+    command:
+      - "echo '--- Fetching Dependencies'"
+      - "./scripts/fetch-develop.deps.sh --depth 1"
+      - "yarn install"
+      - "echo '+++ Testing i18n output'"
+      - "yarn diff-i18n"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:10"
+          mount-buildkite-agent: false
+
+  - wait: ~ # this wait is to perform deploy to /develop only if all other steps passed
+    continue_on_failure: false
+
+  - label: ":hammer: Package"
+    agents:
+      # The tarballs this builds are deployed, so use the slow, burn-after-use queue
+      queue: "release-small"
+    command:
+        - "echo '--- Fetching Dependencies'"
+        - "./scripts/fetch-develop.deps.sh --depth 1"
+        - "yarn install"
+        - "echo '+++ Packaging'"
+        - "./scripts/ci_package.sh"
+    branches: "develop"
+    artifact_paths: "dist/riot-*.tar.gz"
+    plugins:
+        - docker#v3.0.1:
+              image: "node:10"
+              mount-buildkite-agent: false

--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -29,7 +29,7 @@ steps:
           image: "node:12"
           mount-buildkite-agent: false
 
-  - label: ":hammer_and_pick: Build"
+  - label: ":hammer_and_wrench: Build"
     command:
       - "echo '--- Fetching Dependencies'"
       - "./scripts/fetch-develop.deps.sh --depth 1"
@@ -73,7 +73,7 @@ steps:
   - wait: ~ # this wait is to perform deploy to /develop only if all other steps passed
     continue_on_failure: false
 
-  - label: ":hammer: Package"
+  - label: ":package: Package"
     agents:
       # The tarballs this builds are deployed, so use the slow, burn-after-use queue
       queue: "release-small"

--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -78,14 +78,14 @@ steps:
       # The tarballs this builds are deployed, so use the slow, burn-after-use queue
       queue: "release-small"
     command:
-        - "echo '--- Fetching Dependencies'"
-        - "./scripts/fetch-develop.deps.sh --depth 1"
-        - "yarn install"
-        - "echo '+++ Packaging'"
-        - "./scripts/ci_package.sh"
+      - "echo '--- Fetching Dependencies'"
+      - "./scripts/fetch-develop.deps.sh --depth 1"
+      - "yarn install"
+      - "echo '+++ Packaging'"
+      - "./scripts/ci_package.sh"
     branches: "develop"
     artifact_paths: "dist/riot-*.tar.gz"
     plugins:
-        - docker#v3.0.1:
-              image: "node:10"
-              mount-buildkite-agent: false
+      - docker#v3.0.1:
+          image: "node:10"
+          mount-buildkite-agent: false


### PR DESCRIPTION
* Move from riot-web project
 * Add mount-builtkite-agent
 * Use release queue for develop builds