### PR TITLE
Propagate environment for all Riot tests with dependencies

### DIFF
--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -9,6 +9,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":eslint: TS Lint"
@@ -60,6 +63,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"

--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -8,6 +8,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
 # This layer doesn't have a TypeScript linter. This comment is to remind TravisR to fix that.
@@ -39,6 +42,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":jest: Tests"
@@ -56,6 +62,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:10"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":globe_with_meridians: i18n"
@@ -68,6 +77,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:10"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - wait: ~ # this wait is to perform deploy to /develop only if all other steps passed


### PR DESCRIPTION
To ensure we can make changes across several Riot repos at once, we need to
propagate environment to all test runs that install dependencies from other
repos so we can pull matching branches.

Fixes https://github.com/vector-im/riot-web/issues/12553