### PR TITLE
Add pipelines for riot-builder and riot-desktop repos

### DIFF
--- a/riot-builder/pipeline.yaml
+++ b/riot-builder/pipeline.yaml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":eslint: JS Lint"
+    command:
+      - "yarn install"
+      - "yarn run lint"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+          mount-buildkite-agent: false

--- a/riot-desktop/pipeline.yaml
+++ b/riot-desktop/pipeline.yaml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":eslint: Lint"
+    command:
+      - "yarn install"
+      - "yarn lint"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:12"
+          mount-buildkite-agent: false


### PR DESCRIPTION
 * riot-desktop already has a buildkite job that can be switched over to use this pipeline and have contrib CI enabled
 * riot-builder is a new repo that needs a buildkite pipeline adding