### PR TITLE
Up resource availability for riot-web build steps

### DIFF
--- a/riot-web/pipeline.yaml
+++ b/riot-web/pipeline.yaml
@@ -33,6 +33,10 @@ steps:
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"
+    agents:
+      # We use a medium sized instance instead of the normal small ones because
+      # webpack loves to gorge itself on resources.
+      queue: "medium"
     command:
       - "echo '--- Fetching Dependencies'"
       - "./scripts/fetch-develop.deps.sh --depth 1"


### PR DESCRIPTION
This fails surprisingly often due to resource size.