### PR TITLE
Add artifact paths for end to end tests

### DIFF
--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -99,6 +99,9 @@ steps:
       automatic:
         - exit_status: 1 # retry end-to-end tests once as Puppeteer sometimes fails
           limit: 1
+    artifact_paths:
+      - "logs/**/*"
+      - "synapse/installations/consent/homeserver.log"
 
   - label: ":wrench: Riot Tests"
     agents:


### PR DESCRIPTION
They used to use buildkite_agent to upload them but we don't
have this now because mount_agent it turned off.

See also https://github.com/matrix-org/matrix-react-sdk/pull/4232