### PR TITLE
Soft-fail Dendrite SQLite tests

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -91,6 +91,7 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
+    soft_fail: true
     retry:
       automatic:
         - exit_status: -1


### PR DESCRIPTION
This should stop the SQLite tests, which we know are flaky at the moment, from causing the entire pipeline to mark as failed.