### PR TITLE
Update dendrite pipeline to lint using xlarge queue

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -26,11 +26,11 @@ steps:
   - command:
       - "env"
       # https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-      - "GOGC=10 ./scripts/find-lint.sh"
+      - "./scripts/find-lint.sh"
     label: "\U0001F9F9 Lint / :go: 1.13"
     agents:
       # Use a larger instance as linting takes a looot of memory
-      queue: "medium"
+      queue: "xlarge"
     plugins:
       - docker#v3.0.1:
           image: "golang:1.13"


### PR DESCRIPTION
The linter is a *beast* and requires more RAM to stop it from falling over.