### PR TITLE
Make Black print a diff of the changes for Sygnal

### DIFF
--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - command:
       - "python -m pip install black"
-      - "black --check ."
+      - "black --check --diff ."
     label: "Check Code Formatting"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
Otherwise it just says

> would reformat /workdir/sygnal/sygnal.py
> Oh no! 💥 💔 💥

Which isn't very helpful. (cf https://buildkite.com/matrix-dot-org/sygnal/builds/190#7eaf16ba-c64e-4bb1-b7af-a03f3666e7e9)