### PR TITLE
Use medium queue for js-sdk Jest tests because OOM

### DIFF
--- a/matrix-js-sdk/pipeline.yaml
+++ b/matrix-js-sdk/pipeline.yaml
@@ -36,6 +36,10 @@ steps:
           mount-buildkite-agent: false
 
   - label: ":jest: Tests"
+    agents:
+      # We use a medium sized instance instead of the normal small ones because
+      # jest likes our browserified bundle so much it OOMs.
+      queue: "medium"
     command:
       - "yarn install"
       - "yarn test"


### PR DESCRIPTION
https://buildkite.com/matrix-dot-org/matrix-js-sdk/builds/1709#cc6f5698-2e6a-480f-913b-758321975e92

---

@jryans: Relates to https://github.com/matrix-org/matrix-js-sdk/pull/1241