### PR TITLE
Fix typo in towncrier's script for Sydent

### DIFF
--- a/sydent/pipeline.yml
+++ b/sydent/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - command:
       - "echo '--- Install towncrier'"
       - "pip install towncrier"
-      - "echo '+++ Check newsfile"
+      - "echo '+++ Check newsfile'"
       - "python -m towncrier.check"
     label: ":rolled_up_newspaper: Newsfile"
     plugins:


### PR DESCRIPTION
Not entirely sure why it's only coming up now though, as it makes Sydent's CI fail (see https://buildkite.com/matrix-dot-org/sydent/builds/492#1dda068b-4424-45fe-b529-63af4ad82cc1).