### PR TITLE
Dendrite tests with full HTTP APIs

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
         - exit_status: 2
           limit: 2
   
-   - label: "SyTest - :go: 1.13 / :postgres: 9.6 / full HTTP APIs"
+  - label: "SyTest - :go: 1.13 / :postgres: 9.6 / full HTTP APIs"
     agents:
       queue: "medium"
     env:

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -67,10 +67,77 @@ steps:
           limit: 2
         - exit_status: 2
           limit: 2
+  
+   - label: "SyTest - :go: 1.13 / :postgres: 9.6 / full HTTP APIs"
+    agents:
+      queue: "medium"
+    env:
+      POSTGRES: "1"
+      API: "1"
+    command:
+      - "bash build.sh"
+      - "bash /bootstrap.sh dendrite"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-dendrite"
+          propagate-environment: true
+          always-pull: true
+          workdir: "/src"
+          entrypoint: '/bin/sh'
+          shell: ["-x", "-c"]
+          init: false
+          debug: true
+          mount-buildkite-agent: false
+          volumes: ["./logs:/logs"]
+      - artifacts#v1.2.0:
+          upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
+      - matrix-org/annotate:
+          path: "logs/annotate.md"
+          style: "error"
+    soft_fail: true
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
 
   - label: "SyTest - :go: 1.13 / :sqlite: 3"
     agents:
       queue: "medium"
+    command:
+      - "bash build.sh"
+      - "bash /bootstrap.sh dendrite"
+    plugins:
+      - docker#v3.0.1:
+          image: "matrixdotorg/sytest-dendrite"
+          propagate-environment: true
+          always-pull: true
+          workdir: "/src"
+          entrypoint: '/bin/sh'
+          shell: ["-x", "-c"]
+          init: false
+          debug: true
+          mount-buildkite-agent: false
+          volumes: ["./logs:/logs"]
+      - artifacts#v1.2.0:
+          upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
+      - matrix-org/annotate:
+          path: "logs/annotate.md"
+          style: "error"
+    soft_fail: true
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 2
+          limit: 2
+
+  - label: "SyTest - :go: 1.13 / :sqlite: 3 / full HTTP APIs"
+    agents:
+      queue: "medium"
+    env:
+      API: "1"
     command:
       - "bash build.sh"
       - "bash /bootstrap.sh dendrite"


### PR DESCRIPTION
The Dendrite monolith mode normally short-circuits the internal APIs and calls the functions directly, but this means that the HTTP versions of these APIs as used by the polylith components are never tested under Sytest. 

This adds two new stages to the pipeline to use the new full API mode for the Dendrite monolith which will use the HTTP APIs rather than short-circuiting, as this will give us testing that is quite a good emulation of running separate polylith components without actually having to.

They are currently soft-fail. I will update them to fail the pipeline hard once some Dendrite issues are fixed.

Related: matrix-org/dendrite#1057, matrix-org/sytest#877.