### PR TITLE
Use xlarge to try to fix compilation failure due to deamin disappearing

### DIFF
--- a/riotx-android/pipeline.yml
+++ b/riotx-android/pipeline.yml
@@ -6,9 +6,9 @@
 steps:
   - label: "Compile and run Unit tests"
     agents:
-      # We use a medium sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      queue: "medium"
+    # We use a xlarge sized instance instead of the normal small ones because
+    # gradle build can be memory hungry
+      queue: "xlarge"
     commands:
       - "./gradlew clean test --stacktrace"
     plugins:


### PR DESCRIPTION
See for instance https://buildkite.com/matrix-dot-org/riotx-android/builds/2703 and lots of previous builds