### PR TITLE
Don't soft-fail postgres Dendrite sytests

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -124,6 +124,7 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
+    soft_fail: true
     retry:
       automatic:
         - exit_status: -1
@@ -156,6 +157,7 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
+    soft_fail: true
     retry:
       automatic:
         - exit_status: -1

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -94,7 +94,6 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
-    soft_fail: true
     retry:
       automatic:
         - exit_status: -1
@@ -125,7 +124,6 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
-    soft_fail: true
     retry:
       automatic:
         - exit_status: -1
@@ -158,7 +156,6 @@ steps:
       - matrix-org/annotate:
           path: "logs/annotate.md"
           style: "error"
-    soft_fail: true
     retry:
       automatic:
         - exit_status: -1


### PR DESCRIPTION
This removes `soft_fail` on the auxiliary Dendrite tests now as they should be more reliable.