### PR TITLE
Enable mypy typechecking & isort checking for Sygnal

### DIFF
--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -29,8 +29,8 @@ steps:
 
 
   - command:
-      - "python -m pip install isort"
-      - "isort --check-only --diff"
+      - "python -m pip install 'isort~=5.0'"
+      - "isort --check-only --diff ."
     label: "\U0001F9F9 Check import sort"
     plugins:
       - docker#v3.0.1:

--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -27,6 +27,16 @@ steps:
           image: "python:3.7"
           mount-buildkite-agent: false
 
+
+  - command:
+      - "python -m pip install isort"
+      - "isort --check-only --diff"
+    label: "\U0001F9F9 Check import sort"
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.7"
+          mount-buildkite-agent: false
+
   - command:
       - "python -m pip install mypy"
       - "mypy sygnal"

--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -10,36 +10,17 @@ steps:
     branches: "!master !release-*"
 
   - command:
-      - "python -m pip install black"
-      - "black --check --diff ."
-    label: "Check Code Formatting"
-    plugins:
-      - docker#v3.0.1:
-          image: "python:3.7"
-          mount-buildkite-agent: false
-
-  - command:
-      - "python -m pip install flake8"
-      - "flake8 ."
+      - "python -m pip install tox"
+      - "tox -e check_codestyle"
     label: "Check Code Style"
     plugins:
       - docker#v3.0.1:
           image: "python:3.7"
           mount-buildkite-agent: false
 
-
   - command:
-      - "python -m pip install 'isort~=5.0'"
-      - "isort --check-only --diff ."
-    label: "\U0001F9F9 Check import sort"
-    plugins:
-      - docker#v3.0.1:
-          image: "python:3.7"
-          mount-buildkite-agent: false
-
-  - command:
-      - "python -m pip install mypy"
-      - "mypy sygnal"
+      - "python -m pip install tox"
+      - "tox -e check_types"
     label: "Check Types (:mypy:)"
     plugins:
       - docker#v3.0.1:

--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -27,6 +27,15 @@ steps:
           image: "python:3.7"
           mount-buildkite-agent: false
 
+  - command:
+      - "python -m pip install mypy"
+      - "mypy sygnal"
+    label: "Check Types (:mypy:)"
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.7"
+          mount-buildkite-agent: false
+
   - wait
 
   - command:


### PR DESCRIPTION
<del>Not ready yet; waiting on https://github.com/matrix-org/sygnal/pull/131</del>.

Now also uses `tox`.

Signed-off-by: Olivier Wilkinson (reivilibre) <olivier@librepush.net>