### PR TITLE
Prevent mounting BK agent for Sydent builds

### DIFF
--- a/sydent/pipeline.yml
+++ b/sydent/pipeline.yml
@@ -8,6 +8,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.6"
+          mount-buildkite-agent: false
     branches: "!master !release-*"
 
   - command:
@@ -19,6 +20,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:2.7"
+          mount-buildkite-agent: false
     artifact_paths:
       - "_trial_temp/test.log"
 
@@ -34,6 +36,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:2.7"
+          mount-buildkite-agent: false
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"
@@ -47,6 +50,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.5"
+          mount-buildkite-agent: false
     artifact_paths:
       - "_trial_temp/test.log"
 
@@ -62,6 +66,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.5"
+          mount-buildkite-agent: false
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"
@@ -75,6 +80,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.8"
+          mount-buildkite-agent: false
     artifact_paths:
       - "_trial_temp/test.log"
 
@@ -90,6 +96,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "python:3.8"
+          mount-buildkite-agent: false
     artifact_paths:
       - "matrix_is_test/sydent.stderr"
       - "_trial_temp/test.log"


### PR DESCRIPTION
This is done in an effort to allow community PRs to run in CI for Sydent. I compared the pipeline with [synapse's](https://github.com/matrix-org/pipelines/blob/master/synapse/pipeline.yml).

I'm currently unsure whether `propagate-environment` is necessary for Sydent, my guess is that it's necessary if the CI is running any scripts, which Sydent's CI currently does not do.