### PR TITLE
Synapse: Add step to check for unix file endings

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -55,7 +55,7 @@ steps:
       # Run 'file' command on each file, checking for Windows-style line terminators.
       # grep returns exit code 1 when it doesn't find anything. We invert this as
       # finding entries are a bad thing
-      - "find . -type f -exec file '{}' ';' | (! grep 'CRLF line terminators')"
+      - "find . -type f -path './.git/*' -prune -o -exec file '{}' ';' | (! grep 'CRLF line terminators')"
     plugins:
       - docker#v3.0.1:
           image: "python:3.6"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -52,10 +52,7 @@ steps:
 
   - label: "\U0001F5A5 check unix line-endings"
     command:
-      # Run 'file' command on each file, checking for Windows-style line terminators.
-      # grep returns exit code 1 when it doesn't find anything. We invert this as
-      # finding entries are a bad thing
-      - "find . -type f -path './.git/*' -prune -o -exec file '{}' ';' | (! grep 'CRLF line terminators')"
+      - "scripts-dev/check_line_terminators.sh"
     plugins:
       - docker#v3.0.1:
           image: "python:3.6"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -50,6 +50,17 @@ steps:
           image: "python:3.6"
           mount-buildkite-agent: false
 
+  - label: "\U0001F5A5 check unix line-endings"
+    command:
+      # Run 'file' command on each file, checking for Windows-style line terminators.
+      # grep returns exit code 1 when it doesn't find anything. We invert this as
+      # finding entries are a bad thing
+      - "find . -type f -exec file '{}' ';' | (! grep 'CRLF line terminators')"
+    plugins:
+      - docker#v3.0.1:
+          image: "python:3.6"
+          mount-buildkite-agent: false
+
   - label: ":mypy: mypy"
     command:
       - "python -m pip install tox"


### PR DESCRIPTION
To address https://github.com/matrix-org/synapse/issues/7943. I'm using the `python:3.6` image for consistency, but this would probably run on `alpine`.