### PR TITLE
Synapse: Link to the contributing guide if newsfragment check fails

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -33,7 +33,7 @@ steps:
   - label: ":newspaper: Newsfile"
     command:
       - "python -m pip install tox"
-      - "scripts-dev/check-newsfragment"
+      - "scripts-dev/check-newsfragment || echo 'Please see the contributing guide for help: https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog'"
     branches: "!master !develop !release-*"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
There are now multiple cases of community contributors being confused about what to do when the newsfragment check fails:

* https://github.com/matrix-org/synapse/pull/7906#issuecomment-661086316
* https://github.com/matrix-org/synapse/pull/7314#issuecomment-666253337

When `python -m towncrier.check --compare-with=origin/develop` fails, it exits with error code `1`, otherwise exit code `0` when the check succeeds. We use this to `echo` a link to the changelog contributing guide when the check fails, to hopefully allow contributors to be informed and solve the issue themselves.

This was originally a [Synapse PR](https://github.com/matrix-org/synapse/pull/8002), until I realized that the pipeline calls a bash script instead, which does its own checks. Thus we'd want to print the guide on those failing as well.