### PR TITLE
Remove build.sh from Dendrite sytest pipelines

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - command:
       - "env"
-      - "go build ./cmd/..."
+      - "bash build.sh"
     label: "\U0001F528 Build / :go: 1.13"
     plugins:
       - docker#v3.0.1:

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -42,7 +42,6 @@ steps:
     env:
       POSTGRES: "1"
     command:
-      - "bash build.sh"
       - "bash /bootstrap.sh dendrite"
     plugins:
       - docker#v3.0.1:
@@ -75,7 +74,6 @@ steps:
       POSTGRES: "1"
       API: "1"
     command:
-      - "bash build.sh"
       - "bash /bootstrap.sh dendrite"
     plugins:
       - docker#v3.0.1:
@@ -105,7 +103,6 @@ steps:
     agents:
       queue: "medium"
     command:
-      - "bash build.sh"
       - "bash /bootstrap.sh dendrite"
     plugins:
       - docker#v3.0.1:
@@ -138,7 +135,6 @@ steps:
     env:
       API: "1"
     command:
-      - "bash build.sh"
       - "bash /bootstrap.sh dendrite"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
Our `dendrite_sytest.sh` bootstrap script already builds only exactly what Sytest needs to run - the monolith server and `generate-keys` - so we don't need to run `build.sh` here too. It just ends up taking a long time to build all of the components that don't get used during Sytest.