### PR TITLE
[iOS] Fix condition for determining release branches

### DIFF
--- a/element-ios/pipeline.yml
+++ b/element-ios/pipeline.yml
@@ -11,14 +11,14 @@ x-yaml-aliases:
     FASTLANE_SKIP_UPDATE_CHECK: 1
   conditions:
     - &release_branch |
-      // Only on PR builds, and for branches starting with 'release/'
+      // Only on PR builds, and only for 'release/*/release' branches
       build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\/.*\/release/ &&
+        build.branch !~ /^release\// &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds

--- a/element-ios/pipeline.yml
+++ b/element-ios/pipeline.yml
@@ -12,13 +12,13 @@ x-yaml-aliases:
   conditions:
     - &release_branch |
       // Only on PR builds, and for branches starting with 'release/'
-      build.branch =~ /^release\// &&
+      build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\// &&
+        build.branch !~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds

--- a/matrix-ios-kit/pipeline.yml
+++ b/matrix-ios-kit/pipeline.yml
@@ -11,14 +11,14 @@ x-yaml-aliases:
     FASTLANE_SKIP_UPDATE_CHECK: 1
   conditions:
     - &release_branch |
-      // Only on PR builds, and for branches starting with 'release/'
+      // Only on PR builds, and only for 'release/*/release' branches
       build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\/.*\/release/ &&
+        build.branch !~ /^release\// &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds

--- a/matrix-ios-kit/pipeline.yml
+++ b/matrix-ios-kit/pipeline.yml
@@ -12,13 +12,13 @@ x-yaml-aliases:
   conditions:
     - &release_branch |
       // Only on PR builds, and for branches starting with 'release/'
-      build.branch =~ /^release\// &&
+      build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\// &&
+        build.branch !~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds

--- a/matrix-ios-sdk/pipeline.yml
+++ b/matrix-ios-sdk/pipeline.yml
@@ -11,14 +11,14 @@ x-yaml-aliases:
     FASTLANE_SKIP_UPDATE_CHECK: 1
   conditions:
     - &release_branch |
-      // Only on PR builds, and for branches starting with 'release/'
+      // Only on PR builds, and only for 'release/*/release' branches
       build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\/.*\/release/ &&
+        build.branch !~ /^release\// &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds

--- a/matrix-ios-sdk/pipeline.yml
+++ b/matrix-ios-sdk/pipeline.yml
@@ -12,13 +12,13 @@ x-yaml-aliases:
   conditions:
     - &release_branch |
       // Only on PR builds, and for branches starting with 'release/'
-      build.branch =~ /^release\// &&
+      build.branch =~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &feature_branch |
       // Only on PR builds, and for branches other than 'develop', 'master', and 'release/*'
       build.branch != 'master' &&
         build.branch != 'develop' &&
-        build.branch !~ /^release\// &&
+        build.branch !~ /^release\/.*\/release/ &&
         build.env("NIGHTLY_BUILD") == null
     - &nightly |
       // Only for nightly builds


### PR DESCRIPTION
Especially to avoid building `release/x/master` and only build our `release/x/release` branches