### PR TITLE
Run complement as part of Dendrite pipeline

### DIFF
--- a/dendrite/Complement.Dockerfile
+++ b/dendrite/Complement.Dockerfile
@@ -1,0 +1,7 @@
+# This Dockerfile prepares an image with Complement/Docker pre-installed.
+# This allows users of this image to issue `docker build` commands to build their HS
+# and then run Complement against it.
+FROM golang:1.15-buster
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+ADD https://github.com/matrix-org/complement/archive/master.tar.gz .
+RUN tar -xzf master.tar.gz && cd complement-master && go mod download

--- a/dendrite/Complement.Dockerfile
+++ b/dendrite/Complement.Dockerfile
@@ -1,7 +1,0 @@
-# This Dockerfile prepares an image with Complement/Docker pre-installed.
-# This allows users of this image to issue `docker build` commands to build their HS
-# and then run Complement against it.
-FROM golang:1.15-buster
-RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
-ADD https://github.com/matrix-org/complement/archive/master.tar.gz .
-RUN tar -xzf master.tar.gz && cd complement-master && go mod download

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -44,6 +44,7 @@ steps:
       queue: "medium"
     plugins:
       - docker#v3.5.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
           image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -35,6 +35,22 @@ steps:
       - docker#v3.0.1:
           image: "golang:1.13"
           mount-buildkite-agent: false
+
+  - command:
+      - "curl -fsSL https://get.docker.com -o get-docker.sh"
+      - "sh get-docker.sh"
+      - "bash build/scripts/complement.sh"
+    label: "\U0001F9EA Complement"
+    agents:
+      queue: "medium"
+    plugins:
+      - docker#v3.5.0:
+          image: "golang:1.13"
+          mount-buildkite-agent: false
+          propagate-environment: true
+          publish: [ "8448:8448" ]
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
           
   - label: "SyTest - :go: 1.13 / :postgres: 9.6"
     agents:

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
       queue: "medium"
     plugins:
       - docker#v3.5.0:
-          image: "kegsay/complement:latest"
+          image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI
           environment:

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -49,8 +49,12 @@ steps:
       - docker#v3.5.0:
           image: "golang:1.13"
           mount-buildkite-agent: false
-          propagate-environment: true
+          # Complement needs to know if it is running under CI
+          environment:
+           - "CI=true"
           publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
           

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -39,7 +39,9 @@ steps:
   - command:
       - "curl -fsSL https://get.docker.com -o get-docker.sh"
       - "sh get-docker.sh"
-      - "bash build/scripts/complement.sh"
+      - "docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile ."
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
+      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -37,17 +37,14 @@ steps:
           mount-buildkite-agent: false
 
   - command:
-      - "curl -fsSL https://get.docker.com -o get-docker.sh"
-      - "sh get-docker.sh"
-      - "docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile ."
-      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
+      - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
       - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"
     plugins:
       - docker#v3.5.0:
-          image: "golang:1.13"
+          image: "kegsay/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI
           environment:


### PR DESCRIPTION
Tested manually with `bk local run just-this-command.yml` and it all works as intended. There's a number of outstanding questions:
 - Security: This requires the docker socket to be forwarded through to Complement. Can we make some guarantees that this is safe (e.g spot instances?)
 - Security: This uses a [convenience script](https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script) to install Docker, is this okay?
 - Concurrency: When a homeserver tries to talk to Complement it tries to hit `:8448`, which is now published so this can happen. This is a problem if we want to run multiple Complement instances on a single machine. See under using spot instances.
 - ~~Security: Currently this pipeline will execute `build/scripts/complement.sh` which is a script inside of the Dendrite repository. I want to run Complement on Dendrite community PRs - does the fact that we pull the script from Dendrite cause an issue? If so, should I just inline the script in this pipeline? It's 6 lines long.~~