### PR TITLE
Export lint report as build artifacts

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -41,6 +41,7 @@ steps:
       - "mv vector/build/outputs/apk/gplay/debug/*.apk ."
     artifact_paths:
       - "*.apk"
+      - "vector/build/reports/*.*"
     branches: "!master"
     plugins:
       - docker#v3.1.0:
@@ -59,6 +60,7 @@ steps:
       - "mv vector/build/outputs/apk/fdroid/debug/*.apk ."
     artifact_paths:
       - "*.apk"
+      - "vector/build/reports/*.*"
     branches: "!master"
     plugins:
       - docker#v3.1.0:


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/2039

Not tested though, I do not know how to test the pipeline, but it should be OK.