### PR TITLE
Add soft-failing Complement to the Synapse pipeline

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -535,9 +535,14 @@ steps:
   ################################################################################
 
   - command:
+      # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      # Download Complement's source code
       - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
+      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
+      # signing and SSL keys so Synapse can run and federate
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+      # Finally, run the tests. Complement has already been built in the matrixdotorg/complement:latest" image which we're running in
       - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v ./tests"
     label: "\U0001F9EA Complement"
     agents:

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -537,13 +537,16 @@ steps:
   - command:
       # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
-      # Download Complement's source code
-      - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the latest version of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
       # signing and SSL keys so Synapse can run and federate
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
-      # Finally, run the tests. Complement has already been built in the matrixdotorg/complement:latest" image which we're running in
-      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v ./tests"
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -535,7 +535,10 @@ steps:
   ################################################################################
 
   - command:
-      - "bash scripts-dev/complement.sh"
+      - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
+      - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -527,3 +527,31 @@ steps:
 #
 #  - label: Trigger webhook
 #    command: "curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d \"payload[build_num]=$BUILDKITE_BUILD_NUMBER&payload[status]=done\""
+
+  ################################################################################
+  #
+  # Complement Test Suite
+  #
+  ################################################################################
+
+  - command:
+      - "bash scripts-dev/complement.sh"
+    label: "\U0001F9EA Complement"
+    agents:
+      queue: "medium"
+    # Continue even on failure for now
+    soft_fail:
+      - exit_status: 1
+    plugins:
+      - docker#v3.5.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          image: "matrixdotorg/complement:latest"
+          mount-buildkite-agent: false
+          # Complement needs to know if it is running under CI
+          environment:
+           - "CI=true"
+          publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
This PR adds a Complement build step to the Synapse pipeline. It is currently marked as "soft-fail" (meaning this step failing will not block the whole build) as not all complement tests work with Synapse yet.

It is modeled after the existing [Dendrite pipeline entry](https://github.com/matrix-org/pipelines/blob/aa6694b6cde1b5ef5464b6683b8dee5c685ab2a8/dendrite/pipeline.yml#L39-L58), but instead moves the commands to [a script](https://github.com/matrix-org/synapse/blob/ed858b1f97f49f928b4a6e8de7d040bb6f44210b/scripts-dev/complement.sh) inside the Synapse repo.