### PR TITLE
Ignore warnings when compiling tests

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     # gradle build can be memory hungry
       queue: "xlarge"
     commands:
-      - "./gradlew clean test --stacktrace"
+      - "./gradlew clean test --stacktrace -PallWarningsAsErrors=false"
     plugins:
       - docker#v3.1.0:
           image: "runmymind/docker-android-sdk"
@@ -23,7 +23,7 @@ steps:
     # gradle build can be memory hungry
       queue: "xlarge"
     commands:
-      - "./gradlew clean assembleAndroidTest --stacktrace"
+      - "./gradlew clean assembleAndroidTest --stacktrace -PallWarningsAsErrors=false"
     plugins:
       - docker#v3.1.0:
           image: "runmymind/docker-android-sdk"


### PR DESCRIPTION
Add `-PallWarningsAsErrors=false` to ignore warning when compiling tests. Related to https://github.com/vector-im/element-android/pull/2217 and especially https://github.com/vector-im/element-android/pull/2217/commits/6872a488ded562adcdee97c11c3cabbf048f01dd to fix error in https://buildkite.com/matrix-dot-org/element-android/builds/380#58127a63-8709-467e-bd7c-f68fea1964f6

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/3940906/95450946-607cb880-0967-11eb-89bb-1ac7c0f4541e.png">
