### PR TITLE
Increase instance size for worker sytest runs

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -334,7 +334,7 @@ steps:
 
   - label: "SyTest - :python: 3.5 / :postgres: 9.6 / Workers"
     agents:
-      queue: "medium"
+      queue: "xlarge"
     env:
       MULTI_POSTGRES: "1"  # Test with split out databases
       POSTGRES: "1"
@@ -405,7 +405,7 @@ steps:
 
   - label: "SyTest - :python: 3.7 / :postgres: 11 / Workers"
     agents:
-      queue: "medium"
+      queue: "xlarge"
     env:
       MULTI_POSTGRES: "1"  # Test with split out databases
       POSTGRES: "1"

--- a/sytest/pipeline.yml
+++ b/sytest/pipeline.yml
@@ -73,7 +73,7 @@ steps:
 
   - label: "Synapse - :python: 3.5 / :postgres: 9.6 / Workers"
     agents:
-      queue: "medium"
+      queue: "xlarge"
     env:
       POSTGRES: "1"
       WORKERS: "1"
@@ -148,7 +148,7 @@ steps:
 
   - label: "Synapse - :python: 3.7 / :postgres: 11 / Workers"
     agents:
-      queue: "medium"
+      queue: "xlarge"
     env:
       POSTGRES: "1"
       WORKERS: "1"
@@ -184,7 +184,7 @@ steps:
           limit: 2
         - exit_status: 2
           limit: 2
-          
+
   - label: "Dendrite - :go: 1.11 / :postgres: 9.6"
     agents:
       queue: "medium"


### PR DESCRIPTION
We've added more workers which takes them over the memory limit