### PR TITLE
Use matching branches for React SDK TypeScript tasks

### DIFF
--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -16,13 +16,17 @@ steps:
 
   - label: ":eslint: Types Lint"
     command:
-      - "echo '--- Install'"
-      - "yarn install --ignore-scripts"
+      # We fetch the develop js-sdk to get matching types etc.
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "echo '+++ Lint'"
       - "yarn lint:types"
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":stylelint: Style Lint"
@@ -59,11 +63,17 @@ steps:
 
   - label: ":hammer_and_wrench: Build"
     command:
+      # We fetch the develop js-sdk to get matching types etc.
+      - "echo '--- Install js-sdk'"
+      - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "echo '+++ Install & Build'"
       - "yarn install"
     plugins:
       - docker#v3.0.1:
           image: "node:12"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":chains: End-to-End Tests"


### PR DESCRIPTION
React SDK will now depend on types from JS SDK, so it's important that both SDKs
are cloned from matching branches.