### PR TITLE
Do not wait for the whole steps to be run, or even successful to start the εxodus analysis

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -39,7 +39,7 @@ steps:
     commands:
       - "./gradlew clean lintGplayRelease assembleGplayDebug --stacktrace"
       - "mv vector/build/outputs/apk/gplay/debug/*.apk ."
-      key: "elementApp"
+    key: "elementApp"
     artifact_paths:
       - "*.apk"
       - "vector/build/reports/*.*"
@@ -77,7 +77,7 @@ steps:
     commands:
       - "./gradlew clean assembleGplayRelease --stacktrace"
       - "mv vector/build/outputs/apk/gplay/release/*.apk ."
-      key: "elementApp"
+    key: "elementApp"
     artifact_paths:
       - "*.apk"
     branches: "master"

--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -39,6 +39,7 @@ steps:
     commands:
       - "./gradlew clean lintGplayRelease assembleGplayDebug --stacktrace"
       - "mv vector/build/outputs/apk/gplay/debug/*.apk ."
+      key: "elementApp"
     artifact_paths:
       - "*.apk"
       - "vector/build/reports/*.*"
@@ -76,6 +77,7 @@ steps:
     commands:
       - "./gradlew clean assembleGplayRelease --stacktrace"
       - "mv vector/build/outputs/apk/gplay/release/*.apk ."
+      key: "elementApp"
     artifact_paths:
       - "*.apk"
     branches: "master"
@@ -112,8 +114,6 @@ steps:
     command:
       - "diff ./vector/src/main/res/values-id/strings.xml ./vector/src/main/res/values-in/strings.xml"
 
-  - wait
-    
   # run the εxodus static analyser
   - label: "εxodus"
     plugins:
@@ -127,3 +127,4 @@ steps:
       - "mv vector-gplay-universal-*.apk app.apk"
       - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone -j > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
+      depends_on: "elementApp"

--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -127,4 +127,4 @@ steps:
       - "mv vector-gplay-universal-*.apk app.apk"
       - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone -j > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
-      depends_on: "elementApp"
+    depends_on: "elementApp"

--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -39,7 +39,7 @@ steps:
     commands:
       - "./gradlew clean lintGplayRelease assembleGplayDebug --stacktrace"
       - "mv vector/build/outputs/apk/gplay/debug/*.apk ."
-    key: "elementApp"
+    key: "gplay_debug"
     artifact_paths:
       - "*.apk"
       - "vector/build/reports/*.*"
@@ -93,7 +93,7 @@ steps:
     commands:
       - "./gradlew clean assembleGplayRelease --stacktrace"
       - "mv vector/build/outputs/apk/gplay/release/*.apk ."
-    key: "elementApp"
+    key: "gplay_release"
     artifact_paths:
       - "*.apk"
     branches: "master"
@@ -143,4 +143,6 @@ steps:
       - "mv vector-gplay-universal-*.apk app.apk"
       - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone -j > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
-    depends_on: "elementApp"
+    depends_on: 
+      - gplay_debug
+      - gplay_release


### PR DESCRIPTION
This PR is to avoid the εxodus not to be run if an unnecessary step fails, for instance see https://buildkite.com/matrix-dot-org/element-android/builds/484 :

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/3940906/96899553-57283b80-1491-11eb-9a03-6f9df7920dcd.png">

But I'm really not confident to the changes I've made, because I do not know how to test the new pipeline.

Inspired from https://buildkite.com/docs/pipelines/dependencies