### PR TITLE
Remove brand from Element Web artifact path

### DIFF
--- a/element-web/pipeline.yaml
+++ b/element-web/pipeline.yaml
@@ -104,7 +104,7 @@ steps:
       - "echo '+++ Packaging'"
       - "./scripts/ci_package.sh"
     branches: "develop"
-    artifact_paths: "dist/riot-*.tar.gz"
+    artifact_paths: "dist/*.tar.gz"
     plugins:
       - docker#v3.0.1:
           image: "node:12"


### PR DESCRIPTION
This makes the build artifact in the pipeline brand agnostic (since we intend to
rename it).

Part of https://github.com/vector-im/element-web/issues/14896