### PR TITLE
Add build and lint pipeline for complement

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - command:
-      - "env"
-      - "go build -tags *"
+      - env
+      - go build -tags="*"
     label: "\U0001F528 Build / :go: 1.13"
     plugins:
       - docker#v3.7.0:
@@ -13,8 +13,8 @@ steps:
           limit: 3
 
   - command:
-      - "env"
-      - "go build -tags *"
+      - env
+      - go build -tags="*"
     label: "\U0001F528 Build / :go: 1.15"
     plugins:
       - docker#v3.7.0:

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -1,0 +1,38 @@
+steps:
+  - command:
+      - "env"
+      - "go build -tags *"
+    label: "\U0001F528 Build / :go: 1.13"
+    plugins:
+      - docker#v3.7.0:
+          image: "golang:1.13"
+          mount-buildkite-agent: false
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3
+
+  - command:
+      - "env"
+      - "go build -tags *"
+    label: "\U0001F528 Build / :go: 1.15"
+    plugins:
+      - docker#v3.7.0:
+          image: "golang1.15"
+          mount-buildkite-agent: false
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3
+          
+  - command:
+      - "env"
+      # gofmt does not change its exit status depending on whether there are
+      # files in need of formatting. We have to use a slightly hacky way of
+      # checking and then printing the diff instead.
+      - "if [ -n "$(gofmt -l .)" ]; then gofmt -d && exit 1; fi"
+    label: "\U0001F9F9 Linting / :go: 1.15"
+    plugins:
+      - docker#v3.7.0:
+          image: "golang:1.15"
+          mount-buildkite-agent: false

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
   - command:
       - env
-      - go build -tags="*"
-    label: "\U0001F528 Build / :go: 1.13"
+      - go build -tags="*" ./internal/...
+    label: "\U0001F528 Build Complement / :go: 1.13"
     plugins:
       - docker#v3.7.0:
           image: "golang:1.13"
@@ -14,8 +14,8 @@ steps:
 
   - command:
       - env
-      - go build -tags="*"
-    label: "\U0001F528 Build / :go: 1.15"
+      - go build -tags="*" ./internal/...
+    label: "\U0001F528 Build Complement / :go: 1.15"
     plugins:
       - docker#v3.7.0:
           image: "golang1.15"

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -36,3 +36,7 @@ steps:
       - docker#v3.7.0:
           image: "golang:1.15"
           mount-buildkite-agent: false
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -1,6 +1,5 @@
 steps:
   - command:
-      - env
       - go build -tags="*" ./internal/...
     label: "\U0001F528 Build Complement / :go: 1.13"
     plugins:
@@ -13,7 +12,6 @@ steps:
           limit: 3
 
   - command:
-      - env
       - go build -tags="*" ./internal/...
     label: "\U0001F528 Build Complement / :go: 1.15"
     plugins:
@@ -26,7 +24,6 @@ steps:
           limit: 3
 
   - command:
-      - env
       - ./build/scripts/find-lint.sh
     label: "\U0001F9F9 Lint / :go: 1.15"
     agents:

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -18,7 +18,7 @@ steps:
     label: "\U0001F528 Build Complement / :go: 1.15"
     plugins:
       - docker#v3.7.0:
-          image: "golang1.15"
+          image: "golang:1.15"
           mount-buildkite-agent: false
     retry:
       automatic:

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -24,14 +24,14 @@ steps:
       automatic:
         - exit_status: 128
           limit: 3
-          
+
   - command:
-      - "env"
-      # gofmt does not change its exit status depending on whether there are
-      # files in need of formatting. We have to use a slightly hacky way of
-      # checking and then printing the diff instead.
-      - "if [ -n "$(gofmt -l .)" ]; then gofmt -d && exit 1; fi"
-    label: "\U0001F9F9 Linting / :go: 1.15"
+      - env
+      - ./build/scripts/find-lint.sh
+    label: "\U0001F9F9 Lint / :go: 1.15"
+    agents:
+      # Use a larger instance as linting takes a lot of memory
+      queue: "xlarge"
     plugins:
       - docker#v3.7.0:
           image: "golang:1.15"


### PR DESCRIPTION
Adds a simple build and lint pipeline for Complement. Once this is in and works we can add Dendrite and Synapse test runs.

Note that a pipeline entry will need to be created in Buildkite as well.

@Kegsay I've added build tests for Go 1.13 and 1.15 in order to test oldest and newest supported versions of Golang. Let me know if you'd like to do something different there.