### PR TITLE
Add build step to JS SDK tests

### DIFF
--- a/matrix-js-sdk/pipeline.yaml
+++ b/matrix-js-sdk/pipeline.yaml
@@ -33,6 +33,7 @@ steps:
       queue: "medium"
     command:
       - "yarn install"
+      - "yarn build"
       - "yarn test"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-js-sdk/pull/1552, we're moving the browser build step out of the default flow to save time, but it's still needed for tests (since we test it), so this brings it back for only the tests step.

This is safe to land separately from the JS SDK change.