### PR TITLE
Add Synapse and Dendrite runs to Complement's pipeline

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -60,7 +60,7 @@ steps:
            - "CI=true"
           publish: [ "8448:8448" ]
           # Complement uses Docker so pass through the docker socket. This means Complement shares
-          # the hosts Docker.
+          # the host's Docker.
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
     retry:
@@ -87,7 +87,7 @@ steps:
            - "CI=true"
           publish: [ "8448:8448" ]
           # Complement uses Docker so pass through the docker socket. This means Complement shares
-          # the hosts Docker.
+          # the host's Docker.
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
     retry:

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -69,7 +69,7 @@ steps:
 
   - command:
       # Build the Dendrite for Complement docker image
-      - "cd /src && docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile ."
+      - "docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile ."
       # Run the tests!
       - "COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests"
     label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -49,10 +49,7 @@ steps:
       - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
-      # As we provide access to the host docker socket below, use an ephemeral agent which
-      # will be destroyed after this job is complete. This will prevent any potentially
-      # malicious code running in this build agent from tampering with any further jobs.
-      queue: "medium-ephemeral"
+      queue: "medium"
     plugins:
       - docker#v3.7.0:
           # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
@@ -79,10 +76,7 @@ steps:
       - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests
     label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"
     agents:
-      # As we provide access to the host docker socket below, use an ephemeral agent which
-      # will be destroyed after this job is complete. This will prevent any potentially
-      # malicious code running in this build agent from tampering with any further jobs.
-      queue: "medium-ephemeral"
+      queue: "medium"
     plugins:
       - docker#v3.7.0:
           # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -42,13 +42,8 @@ steps:
           limit: 3
 
   - command:
-      # Download the latest checkout of Synapse develop
-      - "wget -N https://github.com/matrix-org/synapse/archive/develop.tar.gz -O synapse.tar.gz && tar -xzf synapse.tar.gz && cd synapse"
-      # Build the Synapse production docker image
-      - docker build -t matrixdotorg/synapse -f docker/Dockerfile .
-      # Now hop over to complement's checkout and build the Complement-specific Synapse docker image,
-      # which inherits from the production Synapse Dockerfile
-      - "cd /src && docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ."
+      # Build the Synapse for Complement docker image, which inherits from the latest Synapse release image on Dockerhub
+      - "docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ."
       # Run the tests!
       - "COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests"
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -49,7 +49,10 @@ steps:
       - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
-      queue: "medium"
+      # As we provide access to the host docker socket below, use an ephemeral agent which
+      # will be destroyed after this job is complete. This will prevent any potentially
+      # malicious code running in this build agent from tampering with any further jobs.
+      queue: "medium-ephemeral"
     plugins:
       - docker#v3.7.0:
           # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
@@ -76,7 +79,10 @@ steps:
       - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests
     label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"
     agents:
-      queue: "medium"
+      # As we provide access to the host docker socket below, use an ephemeral agent which
+      # will be destroyed after this job is complete. This will prevent any potentially
+      # malicious code running in this build agent from tampering with any further jobs.
+      queue: "medium-ephemeral"
     plugins:
       - docker#v3.7.0:
           # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -44,9 +44,9 @@ steps:
   - command:
       # Build the Synapse for Complement docker image, which is located at:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
-      - "docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ."
+      - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests"
+      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
       queue: "medium"
@@ -71,9 +71,9 @@ steps:
   - command:
       # Build the Dendrite for Complement docker image, which is located at:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Dendrite.Dockerfile.
-      - "docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile ."
+      - docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile .
       # Run the tests!
-      - "COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests"
+      - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests
     label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"
     agents:
       queue: "medium"

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -1,3 +1,8 @@
+# WARNING: do not enable builds of third-party PRs on this pipeline. The pipeline is configured to
+# give access to the Docker socket to the Complement test binaries, so a malicious fork of
+# Complement could start a Docker container which extracts the Buildkite agent token and hence
+# compromises this and other Buildkite agents.
+
 steps:
   - command:
       - go build -tags="*" ./internal/...

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -42,7 +42,8 @@ steps:
           limit: 3
 
   - command:
-      # Build the Synapse for Complement docker image, which inherits from the latest Synapse release image on Dockerhub
+      # Build the Synapse for Complement docker image, which is located at:
+      # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
       - "docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ."
       # Run the tests!
       - "COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests"
@@ -68,7 +69,8 @@ steps:
           limit: 3
 
   - command:
-      # Build the Dendrite for Complement docker image
+      # Build the Dendrite for Complement docker image, which is located at:
+      # https://github.com/matrix-org/complement/blob/master/dockerfiles/Dendrite.Dockerfile.
       - "docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile ."
       # Run the tests!
       - "COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests"

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -23,6 +23,9 @@ steps:
         - exit_status: 128
           limit: 3
 
+  - wait
+
+  # Linting can take a while. Run it after the wait to not block the test suite runs
   - command:
       - ./build/scripts/find-lint.sh
     label: "\U0001F9F9 Lint / :go: 1.15"
@@ -33,6 +36,63 @@ steps:
       - docker#v3.7.0:
           image: "golang:1.15"
           mount-buildkite-agent: false
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3
+
+  - command:
+      # Download the latest checkout of Synapse develop
+      - "wget -N https://github.com/matrix-org/synapse/archive/develop.tar.gz -O synapse.tar.gz && tar -xzf synapse.tar.gz && cd synapse"
+      # Build the Synapse production docker image
+      - docker build -t matrixdotorg/synapse -f docker/Dockerfile .
+      # Now hop over to complement's checkout and build the Complement-specific Synapse docker image,
+      # which inherits from the production Synapse Dockerfile
+      - "cd /src && docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile ."
+      # Run the tests!
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests"
+    label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
+    agents:
+      queue: "medium"
+    plugins:
+      - docker#v3.7.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          image: "matrixdotorg/complement:latest"
+          mount-buildkite-agent: false
+          # Complement needs to know if it is running under CI
+          environment:
+           - "CI=true"
+          publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
+    retry:
+      automatic:
+        - exit_status: 128
+          limit: 3
+
+  - command:
+      # Build the Dendrite for Complement docker image
+      - "cd /src && docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile ."
+      # Run the tests!
+      - "COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests"
+    label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"
+    agents:
+      queue: "medium"
+    plugins:
+      - docker#v3.7.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          image: "matrixdotorg/complement:latest"
+          mount-buildkite-agent: false
+          # Complement needs to know if it is running under CI
+          environment:
+           - "CI=true"
+          publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
     retry:
       automatic:
         - exit_status: 128

--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -46,7 +46,7 @@ steps:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
       - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
-      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403" ./tests
+      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
       queue: "medium"


### PR DESCRIPTION
Based on #111. Build steps were mostly based off of Dendrite's Complement steps: https://github.com/matrix-org/pipelines/blob/1a668cc56443ca26e31a8bb8c40130570d54f15f/dendrite/pipeline.yml#L39-L58

Adds build steps for testing Dendrite and Synapse via Complement. **Note that Synapse will fail until https://github.com/matrix-org/synapse/issues/8421 is solved (though that is quite close now).** Hopefully I can come up with a solution to that today. Review of the code should be fine, but I suggest not merging until that issue is resolved.

Another change from #111 is moving the linting step after the `- wait` so that we don't need to wait for it before running Complement tests.