### PR TITLE
Remove redundant steps from React SDK pipeline

### DIFF
--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -47,7 +47,7 @@ steps:
       # the 'build' job.
       - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "yarn run reskindex"
-      - "echo '+++ Running Tests'"
+      - "echo '+++ Test'"
       - "yarn test"
     plugins:
       - docker#v3.0.1:
@@ -80,7 +80,7 @@ steps:
     command:
       - "echo '--- Install js-sdk'"
       - "./scripts/ci/install-deps.sh --ignore-scripts"
-      - "echo '+++ Running Tests'"
+      - "echo '+++ Test'"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:
       - docker#v3.0.1:
@@ -104,7 +104,7 @@ steps:
       # webpack loves to gorge itself on resources.
       queue: "medium"
     command:
-      - "echo '+++ Running Tests'"
+      - "echo '+++ Test'"
       - "./scripts/ci/app-tests.sh"
     plugins:
       - docker#v3.0.1:
@@ -117,9 +117,9 @@ steps:
 
   - label: ":globe_with_meridians: i18n"
     command:
-      - "echo '--- Fetching Dependencies'"
+      - "echo '--- Install'"
       - "yarn install --ignore-scripts"
-      - "echo '+++ Testing i18n output'"
+      - "echo '+++ Test'"
       - "yarn diff-i18n"
     plugins:
       - docker#v3.0.1:

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -78,8 +78,6 @@ steps:
       # e2e tests otherwise take +-8min
       queue: "xlarge"
     command:
-      - "echo '--- Install js-sdk'"
-      - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "echo '+++ Test'"
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -64,6 +64,7 @@ steps:
       - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "echo '+++ Install & Build'"
       - "yarn install"
+      - "yarn build"
     plugins:
       - docker#v3.0.1:
           image: "node:12"

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -62,8 +62,7 @@ steps:
       # We fetch the develop js-sdk to get matching types etc.
       - "echo '--- Install js-sdk'"
       - "./scripts/ci/install-deps.sh --ignore-scripts"
-      - "echo '+++ Install & Build'"
-      - "yarn install"
+      - "echo '+++ Build'"
       - "yarn build"
     plugins:
       - docker#v3.0.1:

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -1,17 +1,13 @@
 steps:
   - label: ":eslint: JS Lint"
     command:
-      # We fetch the develop js-sdk to get our latest eslint rules
-      - "echo '--- Install js-sdk'"
-      - "./scripts/ci/install-deps.sh --ignore-scripts"
+      - "echo '--- Install'"
+      - "yarn install --ignore-scripts"
       - "echo '+++ Lint'"
       - "yarn lint:js"
     plugins:
       - docker#v3.0.1:
           image: "node:12"
-          # This allows the test script to see what branch it's testing and check
-          # out the equivalent dependency branches, if they exist
-          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":eslint: Types Lint"

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -78,7 +78,7 @@ steps:
       # e2e tests otherwise take +-8min
       queue: "xlarge"
     command:
-      - "echo '+++ Test'"
+      # `end-to-end-tests.sh` contains `echo` commands to mark sections
       - "./scripts/ci/end-to-end-tests.sh"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
As part of working on related build changes in https://github.com/matrix-org/matrix-react-sdk/pull/5503, I noticed several pipeline steps that duplicate work done elsewhere. This removes duplication and applies some other misc. cleaning to normalise log lines and such.

Part of https://github.com/vector-im/element-web/issues/15987