### PR TITLE
Add instructions on how to run pipelines locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Buildkite Pipelines for Matrix.org Projects.
 See the intructions at
 https://gitlab.matrix.org/new-vector/internal/-/wikis/BuildKite#testing-a-pipeline-locally.
 
-This is an internal page. If you are not allowed to view this page, know that
+The above is an internal page. If you are not allowed to view this page, know that
 the instructions effectively boil down to:
 
 1. Install [buildkite-agent](https://github.com/buildkite/agent) and [buildkite-cli](https://github.com/buildkite/cli).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # pipelines
-Buildkite Pipelines for Matrix.org Projects
+Buildkite Pipelines for Matrix.org Projects.
+
+## Testing a pipeline locally
+
+If you would like to test a change to a pipeline before merging to this repo,
+you can opt to run the pipeline on your local machine.
+
+1. Install [buildkite-agent](https://github.com/buildkite/agent) and [buildkite-cli](https://github.com/buildkite/cli).
+2. Login to buildkite with `bk configure buildkite`.
+3. Create your own Buildkite organisation. This is to ensure separation of
+   production agents from developer computers. Do so from the drop-down on
+   https://buildkite.com once signed in.
+4. Configure your buildkite agent token. This should be the agent token of
+   the org you just created. You can find your organisation's agent token under
+   https://buildkite.com/organizations/YOUR_ORG_NAME/agents.
+5. Change to the directory of the project you'd like to test (e.g. `cd
+   /path/to/synapse`) and do `bk run /path/to/pipelines-repo/PROJECT_NAME/pipeline.yml`.

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@ Buildkite Pipelines for Matrix.org Projects.
 
 ## Testing a pipeline locally
 
-If you would like to test a change to a pipeline before merging to this repo,
-you can opt to run the pipeline on your local machine.
+See the intructions at
+https://gitlab.matrix.org/new-vector/internal/-/wikis/BuildKite#testing-a-pipeline-locally.
+
+This is an internal page. If you are not allowed to view this page, know that
+the instructions effectively boil down to:
 
 1. Install [buildkite-agent](https://github.com/buildkite/agent) and [buildkite-cli](https://github.com/buildkite/cli).
-2. Login to buildkite with `bk configure buildkite`.
-3. Create your own Buildkite organisation. This is to ensure separation of
-   production agents from developer computers. Do so from the drop-down on
-   https://buildkite.com once signed in.
-4. Configure your buildkite agent token. This should be the agent token of
-   the org you just created. You can find your organisation's agent token under
-   https://buildkite.com/organizations/YOUR_ORG_NAME/agents.
-5. Change to the directory of the project you'd like to test (e.g. `cd
-   /path/to/synapse`) and do `bk run /path/to/pipelines-repo/PROJECT_NAME/pipeline.yml`.
+2. Change to the codebase directory of the project you'd like to test.
+3. Run `bk local run /path/to/project/pipeline.yml`.
+
+Note that `--debug` can be added to the above command to produce
+some more helpful logs.


### PR DESCRIPTION
I wanted to test #114 locally, and found out a working method to do so. I'd be a little surprised if this were the most direct method however, as it requires retrieving tokens from buildkite and creating an organisation just to run some tests locally.

I found that attempting to run `bk local run /path/to/pipeline.yml` would fail unless `buildkite-agent` was running though, and `buildkite-agent` refused to start up without a valid agent token, so ¯\\\_(ツ)_/¯.

I'm hoping that this won't mean a bunch of random organisations get littered over someone's dashboard somewhere though, or whether we should set up a single, testing organisation for this purpose instead.