### PR TITLE
Use blacklist and remove soft-fail status for Synapse's Complement run

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -577,9 +577,6 @@ steps:
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"
-    # Continue even on failure for now
-    soft_fail:
-      - exit_status: 1
     plugins:
       - docker#v3.7.0:
           # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -573,7 +573,7 @@ steps:
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v ./tests"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags "synapse_blacklist" ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
Once https://github.com/matrix-org/synapse/issues/8421 is sorted (one outstanding PR) Synapse should now pass all generally applicable tests in Complement. At this point, we'll want to no longer soft-fail Complement CI runs so that we'll be alerted if we break anything.

This PR also sets Synapse's Complement blacklist, which was introduced in https://github.com/matrix-org/complement/pull/55.

Mergable once https://github.com/matrix-org/pipelines/pull/114 is in and Complement's CI shows Synapse as green.