### PR TITLE
Synapse: Add a step for running Complement tests in worker mode

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -27,6 +27,9 @@ x-yaml-aliases:
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
 
+    # The common command for running Complement tests against Synapse
+    - &complement_run_tests_command "go test -v -tags synapse_blacklist,msc2946,msc3083 ./tests"
+
   retry: &retry_setup
     automatic:
       - exit_status: -1
@@ -590,10 +593,12 @@ steps:
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
       # signing and SSL keys so Synapse can run and federate
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+      - "export COMPLEMENT_BASE_IMAGE=complement-synapse"
 
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc2946,msc3083 ./tests"
+      - *complement_run_tests_command
+
     label: "\U0001F9EA Complement | Synapse Monolith"
     agents:
       queue: "medium"
@@ -619,11 +624,12 @@ steps:
       - "tar -xzf master.tar.gz"
       # Build an image for running the above worker setup in Complement. This involves
       # disabling rate-limiting, using Complement's CA etc.
-      - "docker build -t complement-synapse -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
+      - "docker build -t complement-synapse-workers -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
+      - "export COMPLEMENT_BASE_IMAGE=complement-synapse-workers"
 
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc2946,msc3083 ./tests"
+      - *complement_run_tests_command
     label: "\U0001F9EA Complement | Synapse Workers"
     agents:
       # Running every worker takes a beefy system

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -21,8 +21,6 @@ x-yaml-aliases:
           - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest"
           # Complement needs to know if it is running under CI
           - "CI=true"
-          # Enable debug logging
-          - "COMPLEMENT_DEBUG=1"
         publish: [ "8448:8448" ]
         # Complement uses Docker so pass through the docker socket. This means Complement shares
         # the hosts Docker.

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -545,7 +545,7 @@ steps:
       # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
       # We use the complement:latest image to provide Complement's dependencies, but want
-      # to actually run against the latest version of Complement, so download it here.
+      # to actually run against the master branch of Complement, so download it here.
       - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
       - "tar -xzf master.tar.gz"
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
@@ -554,7 +554,7 @@ steps:
       # Finally, compile and run the tests.
       - "cd complement-master"
       - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
-    label: "\U0001F9EA Complement"
+    label: "\U0001F9EA Complement | Synapse Monolith"
     agents:
       queue: "medium"
     plugins:
@@ -565,6 +565,49 @@ steps:
           # Complement needs to know if it is running under CI
           environment:
            - "CI=true"
+          publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
+
+  - command:
+      # Build a docker image from the checked out Synapse source
+      - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      # Build a second docker image on top of the above image. This one sets up Synapse workers
+      # as well as everything else it needs to run a federating setup
+      - "docker build -t matrixdotorg/synapse:workers -f docker/Dockerfile-workers ."
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the master branch of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
+      # Build an image for running the above worker setup in Complement. This involves
+      # disabling rate-limiting, using Complement's CA etc.
+      - "docker build -t complement-synapse -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
+    label: "\U0001F9EA Complement | Synapse Workers"
+    agents:
+      # Running every worker takes a beefy system
+      queue: "xlarge"
+    plugins:
+      - docker#v3.7.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          image: "matrixdotorg/complement:latest"
+          mount-buildkite-agent: false
+          environment:
+            # Complement needs to know if it is running under CI
+            - "CI=true"
+            # Enable debug logging
+            - "COMPLEMENT_DEBUG=1"
+            # Enabled Complement's certificate authority for authentication of
+            # federation requests
+            - "COMPLEMENT_CA=true"
+            # Starting up all the processes in this container can take a little while.
+            # The default is 200. Let's wait a bit longer to decrease the chance of a
+            # startup timeout
+            - "COMPLEMENT_VERSION_CHECK_ITERATIONS=500"
           publish: [ "8448:8448" ]
           # Complement uses Docker so pass through the docker socket. This means Complement shares
           # the hosts Docker.

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -575,8 +575,6 @@ steps:
   #
   ################################################################################
 
-
-
   - command:
       # Build the necessary docker images and start Complement.
       # Note: We can't place the below steps in a Synapse repo script as this code is

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -10,6 +10,25 @@ x-yaml-aliases:
       apt-get update && apt-get install -y xmlsec1
       python -m pip install tox
 
+  plugins:
+    - docker#v3.7.0: &complement_docker_common
+        # The dockerfile for this image is at
+        # https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+        image: "matrixdotorg/complement:latest"
+        mount-buildkite-agent: false
+        environment: &complement_docker_environment_common
+          # Specify the docker image to run tests against
+          - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest"
+          # Complement needs to know if it is running under CI
+          - "CI=true"
+          # Enable debug logging
+          - "COMPLEMENT_DEBUG=1"
+        publish: [ "8448:8448" ]
+        # Complement uses Docker so pass through the docker socket. This means Complement shares
+        # the hosts Docker.
+        volumes:
+          - "/var/run/docker.sock:/var/run/docker.sock"
+
   retry: &retry_setup
     automatic:
       - exit_status: -1
@@ -549,6 +568,7 @@ steps:
 
       # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+
       # We use the complement:latest image to provide Complement's dependencies, but want
       # to actually run against the master branch of Complement, so download it here.
       - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
@@ -556,25 +576,16 @@ steps:
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
       # signing and SSL keys so Synapse can run and federate
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
+      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Monolith"
     agents:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
-          image: "matrixdotorg/complement:latest"
-          mount-buildkite-agent: false
-          # Complement needs to know if it is running under CI
-          environment:
-           - "CI=true"
-          publish: [ "8448:8448" ]
-          # Complement uses Docker so pass through the docker socket. This means Complement shares
-          # the hosts Docker.
-          volumes:
-            - "/var/run/docker.sock:/var/run/docker.sock"
+          <<: *complement_docker_common
 
   - command:
       # Build the necessary docker images and start Complement.
@@ -587,6 +598,7 @@ steps:
       # Build a second docker image on top of the above image. This one sets up Synapse workers
       # as well as everything else it needs to run a federating setup
       - "docker build -t matrixdotorg/synapse:workers -f docker/Dockerfile-workers ."
+
       # We use the complement:latest image to provide Complement's dependencies, but want
       # to actually run against the master branch of Complement, so download it here.
       - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
@@ -594,23 +606,20 @@ steps:
       # Build an image for running the above worker setup in Complement. This involves
       # disabling rate-limiting, using Complement's CA etc.
       - "docker build -t complement-synapse -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
+
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
+      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Workers"
     agents:
       # Running every worker takes a beefy system
       queue: "xlarge"
     plugins:
       - docker#v3.7.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
-          image: "matrixdotorg/complement:latest"
-          mount-buildkite-agent: false
+          <<: *complement_docker_common
+          # Override the default plugin settings
           environment:
-            # Complement needs to know if it is running under CI
-            - "CI=true"
-            # Enable debug logging
-            - "COMPLEMENT_DEBUG=1"
+            - *complement_docker_environment_common
             # Enable Complement's certificate authority for authentication of federation
             # requests
             - "COMPLEMENT_CA=true"
@@ -618,8 +627,3 @@ steps:
             # The default is 200. Let's wait a bit longer to decrease the chance of a
             # startup timeout
             - "COMPLEMENT_VERSION_CHECK_ITERATIONS=500"
-          publish: [ "8448:8448" ]
-          # Complement uses Docker so pass through the docker socket. This means Complement shares
-          # the hosts Docker.
-          volumes:
-            - "/var/run/docker.sock:/var/run/docker.sock"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -542,6 +542,11 @@ steps:
   ################################################################################
 
   - command:
+      # Build the necessary docker images and start Complement.
+      # Note: We can't place the below steps in a Synapse repo script as this code is
+      # given access to the host docker socket. We don't want to allow untrusted code
+      # to be executed with those privileges.
+
       # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
       # We use the complement:latest image to provide Complement's dependencies, but want
@@ -572,6 +577,11 @@ steps:
             - "/var/run/docker.sock:/var/run/docker.sock"
 
   - command:
+      # Build the necessary docker images and start Complement.
+      # Note: We can't place the below steps in a Synapse repo script as this code is
+      # given access to the host docker socket. We don't want to allow untrusted code
+      # to be executed with those privileges.
+
       # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
       # Build a second docker image on top of the above image. This one sets up Synapse workers

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -10,6 +10,25 @@ x-yaml-aliases:
       apt-get update && apt-get install -y xmlsec1
       python -m pip install tox
 
+    # Note: We can't place the below steps in a Synapse repo script as this code is
+    # given access to the host docker socket. We don't want to allow untrusted code
+    # to be executed with those privileges.
+    - complement_commands_common: &complement_commands_common
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the master branch of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
+
+      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
+      # signing and SSL keys so Synapse can run and federate. The value of the environment
+      # variable determines which Synapse-flavoured dockerfile to use from Complement repo.
+      - "docker build -t complement-synapse -f $SYNAPSE_COMPLEMENT_DOCKERFILE complement-master/dockerfiles"
+
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "go test -v -tags synapse_blacklist ./tests"
+
+
   plugins:
     - docker#v3.7.0: &complement_docker_common
         # The dockerfile for this image is at
@@ -564,50 +583,37 @@ steps:
       # given access to the host docker socket. We don't want to allow untrusted code
       # to be executed with those privileges.
 
-      # Build a docker image from the checked out Synapse source
+      # Build a base docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
 
-      # We use the complement:latest image to provide Complement's dependencies, but want
-      # to actually run against the master branch of Complement, so download it here.
-      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
-      - "tar -xzf master.tar.gz"
-      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
-      # signing and SSL keys so Synapse can run and federate
-      - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+      # Build the final dockerfile and run the tests
+      *complement_commands_common
 
-      # Finally, compile and run the tests.
-      - "cd complement-master"
-      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Monolith"
     agents:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
           <<: *complement_docker_common
+          # Override the default plugin settings
+          environment:
+            - *complement_docker_environment_common
+            # Use a Synapse Monolith Dockerfile from Complement. This dockerfile is located at:
+            # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile
+            - "SYNAPSE_COMPLEMENT_DOCKERFILE=complement-master/dockerfiles/Synapse.Dockerfile"
 
   - command:
       # Build the necessary docker images and start Complement.
-      # Note: We can't place the below steps in a Synapse repo script as this code is
-      # given access to the host docker socket. We don't want to allow untrusted code
-      # to be executed with those privileges.
 
-      # Build a docker image from the checked out Synapse source
+      # Build a base docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+
       # Build a second docker image on top of the above image. This one sets up Synapse workers
-      # as well as everything else it needs to run a federating setup
       - "docker build -t matrixdotorg/synapse:workers -f docker/Dockerfile-workers ."
 
-      # We use the complement:latest image to provide Complement's dependencies, but want
-      # to actually run against the master branch of Complement, so download it here.
-      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
-      - "tar -xzf master.tar.gz"
-      # Build an image for running the above worker setup in Complement. This involves
-      # disabling rate-limiting, using Complement's CA etc.
-      - "docker build -t complement-synapse -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
+      # Build the final dockerfile and run the tests
+      *complement_commands_common
 
-      # Finally, compile and run the tests.
-      - "cd complement-master"
-      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Workers"
     agents:
       # Running every worker takes a beefy system
@@ -618,6 +624,9 @@ steps:
           # Override the default plugin settings
           environment:
             - *complement_docker_environment_common
+            # Use the Synapse Worker Dockerfile from Complement. This dockerfile is located at:
+            # https://github.com/matrix-org/complement/blob/master/dockerfiles/SynapseWorkers.Dockerfile
+            - "SYNAPSE_COMPLEMENT_DOCKERFILE=complement-master/dockerfiles/SynapseWorkers.Dockerfile"
             # Enable Complement's certificate authority for authentication of federation
             # requests
             - "COMPLEMENT_CA=true"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -10,25 +10,6 @@ x-yaml-aliases:
       apt-get update && apt-get install -y xmlsec1
       python -m pip install tox
 
-    # Note: We can't place the below steps in a Synapse repo script as this code is
-    # given access to the host docker socket. We don't want to allow untrusted code
-    # to be executed with those privileges.
-    - complement_commands_common: &complement_commands_common
-      # We use the complement:latest image to provide Complement's dependencies, but want
-      # to actually run against the master branch of Complement, so download it here.
-      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
-      - "tar -xzf master.tar.gz"
-
-      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
-      # signing and SSL keys so Synapse can run and federate. The value of the environment
-      # variable determines which Synapse-flavoured dockerfile to use from Complement repo.
-      - "docker build -t complement-synapse -f $SYNAPSE_COMPLEMENT_DOCKERFILE complement-master/dockerfiles"
-
-      # Finally, compile and run the tests.
-      - "cd complement-master"
-      - "go test -v -tags synapse_blacklist ./tests"
-
-
   plugins:
     - docker#v3.7.0: &complement_docker_common
         # The dockerfile for this image is at
@@ -583,37 +564,50 @@ steps:
       # given access to the host docker socket. We don't want to allow untrusted code
       # to be executed with those privileges.
 
-      # Build a base docker image from the checked out Synapse source
+      # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
 
-      # Build the final dockerfile and run the tests
-      *complement_commands_common
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the master branch of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
+      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
+      # signing and SSL keys so Synapse can run and federate
+      - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
 
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Monolith"
     agents:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
           <<: *complement_docker_common
-          # Override the default plugin settings
-          environment:
-            - *complement_docker_environment_common
-            # Use a Synapse Monolith Dockerfile from Complement. This dockerfile is located at:
-            # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile
-            - "SYNAPSE_COMPLEMENT_DOCKERFILE=complement-master/dockerfiles/Synapse.Dockerfile"
 
   - command:
       # Build the necessary docker images and start Complement.
+      # Note: We can't place the below steps in a Synapse repo script as this code is
+      # given access to the host docker socket. We don't want to allow untrusted code
+      # to be executed with those privileges.
 
-      # Build a base docker image from the checked out Synapse source
+      # Build a docker image from the checked out Synapse source
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
-
       # Build a second docker image on top of the above image. This one sets up Synapse workers
+      # as well as everything else it needs to run a federating setup
       - "docker build -t matrixdotorg/synapse:workers -f docker/Dockerfile-workers ."
 
-      # Build the final dockerfile and run the tests
-      *complement_commands_common
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the master branch of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
+      # Build an image for running the above worker setup in Complement. This involves
+      # disabling rate-limiting, using Complement's CA etc.
+      - "docker build -t complement-synapse -f complement-master/dockerfiles/SynapseWorkers.Dockerfile complement-master/dockerfiles"
 
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "go test -v -tags synapse_blacklist ./tests"
     label: "\U0001F9EA Complement | Synapse Workers"
     agents:
       # Running every worker takes a beefy system
@@ -624,9 +618,6 @@ steps:
           # Override the default plugin settings
           environment:
             - *complement_docker_environment_common
-            # Use the Synapse Worker Dockerfile from Complement. This dockerfile is located at:
-            # https://github.com/matrix-org/complement/blob/master/dockerfiles/SynapseWorkers.Dockerfile
-            - "SYNAPSE_COMPLEMENT_DOCKERFILE=complement-master/dockerfiles/SynapseWorkers.Dockerfile"
             # Enable Complement's certificate authority for authentication of federation
             # requests
             - "COMPLEMENT_CA=true"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -611,8 +611,8 @@ steps:
             - "CI=true"
             # Enable debug logging
             - "COMPLEMENT_DEBUG=1"
-            # Enabled Complement's certificate authority for authentication of
-            # federation requests
+            # Enable Complement's certificate authority for authentication of federation
+            # requests
             - "COMPLEMENT_CA=true"
             # Starting up all the processes in this container can take a little while.
             # The default is 200. Let's wait a bit longer to decrease the chance of a

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -584,7 +584,7 @@ steps:
       # to be executed with those privileges.
 
       # Build a docker image from the checked out Synapse source
-      - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      - "docker build -t matrixdotorg/synapse -f docker/Dockerfile ."
 
       # We use the complement:latest image to provide Complement's dependencies, but want
       # to actually run against the master branch of Complement, so download it here.
@@ -613,10 +613,10 @@ steps:
       # to be executed with those privileges.
 
       # Build a docker image from the checked out Synapse source
-      - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      - "docker build -t matrixdotorg/synapse -f docker/Dockerfile ."
       # Build a second docker image on top of the above image. This one sets up Synapse workers
       # as well as everything else it needs to run a federating setup
-      - "docker build -t matrixdotorg/synapse:workers -f docker/Dockerfile-workers ."
+      - "docker build -t matrixdotorg/synapse-workers -f docker/Dockerfile-workers ."
 
       # We use the complement:latest image to provide Complement's dependencies, but want
       # to actually run against the master branch of Complement, so download it here.


### PR DESCRIPTION
This PR extends the Complement section of Synapse's pipeline to run Complement tests under worker mode. This PR is ready for review, but should not be merged until the relevant [Synapse](https://github.com/matrix-org/synapse/pull/9162) and [Complement](https://github.com/matrix-org/complement/pull/62) PRs are.

## How does this work?

We start with the official Synapse docker image. This creates a python environment with all of Synapse's dependencies installed. Then we make use of the new `Dockerfile-workers` to install supervisord, redis and nginx. Redis is used for inter-process communication, nginx is used for routing network requests to each worker and supervisord will start and maintain each process.

Finally, we use the `SynapseWorkers` dockerfile in Complement to install postgresql into the container, set up caddy server to easily take advantage of Complement's CA, inject some Synapse options to disable rate-limiting, enable registration etc. and then finally run a script which generates config files supervisord, nginx and Synapse depending on which workers you want to run.