### PR TITLE
Upgrade Element Web pipelines to modern Node and base OS

### DIFF
--- a/element-builder/pipeline.yaml
+++ b/element-builder/pipeline.yaml
@@ -5,5 +5,5 @@ steps:
       - "yarn lint"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false

--- a/element-desktop/pipeline.yaml
+++ b/element-desktop/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
       - "yarn lint"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true

--- a/element-web/pipeline.yaml
+++ b/element-web/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
       - "yarn lint:js"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -21,7 +21,7 @@ steps:
 #      - "yarn lint:ts"
 #    plugins:
 #      - docker#v3.0.1:
-#          image: "node:12"
+#          image: "node:14-buster"
 
   - label: ":eslint: Types Lint"
     command:
@@ -32,7 +32,7 @@ steps:
       - "yarn lint:types"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"
@@ -49,7 +49,7 @@ steps:
     artifact_paths: "webpack-stats.json"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -69,7 +69,7 @@ steps:
       - "yarn test"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -84,7 +84,7 @@ steps:
       - "yarn diff-i18n"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -107,5 +107,5 @@ steps:
     artifact_paths: "dist/*.tar.gz"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false

--- a/matrix-js-sdk/pipeline.yaml
+++ b/matrix-js-sdk/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
       - "yarn lint:js"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":typescript: Types Lint"
@@ -14,7 +14,7 @@ steps:
       - "yarn lint:types"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"
@@ -23,7 +23,7 @@ steps:
       - "yarn build"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":jest: Tests"
@@ -37,7 +37,7 @@ steps:
       - "yarn test"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":page_with_curl: Docs"
@@ -46,7 +46,7 @@ steps:
       - "yarn gendoc"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - wait

--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
       - "yarn lint:js"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":eslint: Types Lint"
@@ -19,7 +19,7 @@ steps:
       - "yarn lint:types"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -32,7 +32,7 @@ steps:
       - "yarn lint:style"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":jest: Tests"
@@ -51,7 +51,7 @@ steps:
       - "yarn test"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -66,7 +66,7 @@ steps:
       - "yarn build"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -106,7 +106,7 @@ steps:
       - "./scripts/ci/app-tests.sh"
     plugins:
       - docker#v3.0.1:
-          image: "node:10"
+          image: "node:14-buster"
           # This allows the test script to see what branch it's testing and check
           # out the equivalent dependency branches, if they exist
           propagate-environment: true
@@ -121,7 +121,7 @@ steps:
       - "yarn diff-i18n"
     plugins:
       - docker#v3.0.1:
-          image: "node:10"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - wait

--- a/matrix-widget-api/pipeline.yml
+++ b/matrix-widget-api/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - "yarn lint:ts"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":eslint: Types Lint"
@@ -14,7 +14,7 @@ steps:
       - "yarn lint:types"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"
@@ -23,5 +23,5 @@ steps:
       - "yarn build"
     plugins:
       - docker#v3.0.1:
-          image: "node:12"
+          image: "node:14-buster"
           mount-buildkite-agent: false


### PR DESCRIPTION
This changes all Element Web steps to use Node 14 (current LTS) and Debian Buster (current stable) as the base OS.