### PR TITLE
Install golangci-lint gomatrixserverlib pipeline

### DIFF
--- a/gomatrixserverlib/pipeline.yml
+++ b/gomatrixserverlib/pipeline.yml
@@ -10,6 +10,7 @@ steps:
 
   - command:
       - "go version"
+      - "go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.35.2"
       - "golangci-lint run"
     label: "\U0001F9F9 Lint / :go: 1.13"
     agents:


### PR DESCRIPTION
Apparently this isn't in the go1.13 image as I thought it was. Have tested locally with `bk local` and seems to be running the linter now.