### PR TITLE
Synapse: Only check for newsfile on pull requests

### DIFF
--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -50,6 +50,7 @@ steps:
           mount-buildkite-agent: false
 
   - label: ":newspaper: Newsfile"
+    if: "build.pull_request.id != null" # Only run this check on pull requests
     command:
       - "python -m pip install tox"
       - "scripts-dev/check-newsfragment"


### PR DESCRIPTION
Every once in a while I want to manually build a branch without creating a PR. This makes it possible for that to succeed.