### PR TITLE
Use matching branches for Element Web types lint

### DIFF
--- a/element-web/pipeline.yaml
+++ b/element-web/pipeline.yaml
@@ -33,6 +33,9 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:14-buster"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
           mount-buildkite-agent: false
 
   - label: ":hammer_and_wrench: Build"


### PR DESCRIPTION
As with other steps in this pipeline, we need to propagate the environment for
types linting as well to allow access to matching branches in the other layers.