### PR TITLE
Enable Complement tests for MSC3083.

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -27,7 +27,7 @@ steps:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
       - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
-      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist" ./tests
+      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc3083" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -579,7 +579,7 @@ steps:
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc3083 ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
Enable additional complement tests added in matrix-org/complement#98 for matrix-org/synapse#9735.

I think we need to merge the Synapse PR before these will pass?