### PR TITLE
Enable MSC2946 tests in Complement for Synapse and Complement pipelines.

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -27,7 +27,7 @@ steps:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
       - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
-      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc3083" ./tests
+      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2946,msc3083" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -567,7 +567,7 @@ steps:
       - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
       # Finally, compile and run the tests.
       - "cd complement-master"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc3083 ./tests"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc2946,msc3083 ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
Pretty much the same as #139, but for matrix-org/synapse#9771 / matrix-org/complement#101.