### PR TITLE
Fix Element Desktop lint step

### DIFF
--- a/element-desktop/pipeline.yaml
+++ b/element-desktop/pipeline.yaml
@@ -5,6 +5,14 @@ steps:
       - "echo '--- Install js-sdk'"
       - "./scripts/ci/install-deps.sh --ignore-scripts"
       - "yarn lint"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:14-buster"
+          # This allows the test script to see what branch it's testing and check
+          # out the equivalent dependency branches, if they exist
+          propagate-environment: true
+          mount-buildkite-agent: false
+
   - label: ":globe_with_meridians: i18n"
     command:
       - "echo '--- Fetching Dependencies'"
@@ -14,7 +22,4 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "node:14-buster"
-          # This allows the test script to see what branch it's testing and check
-          # out the equivalent dependency branches, if they exist
-          propagate-environment: true
           mount-buildkite-agent: false


### PR DESCRIPTION
https://github.com/matrix-org/pipelines/pull/142 added an extra CI step, but since the plugins are part of each step, that change meant that the pre-existing lint step no longer had a Docker image.

This fixes things up by setting up the plugins for each step.

This is safe to merge at any time.