### PR TITLE
Run IRC bridge tests on Node 16

### DIFF
--- a/matrix-appservice-irc/pipeline.yml
+++ b/matrix-appservice-irc/pipeline.yml
@@ -25,6 +25,15 @@ steps:
       - docker#v3.0.1:
           image: "node:14"
           mount-buildkite-agent: false
+          
+  - label: ":jasmine: Tests Node 16"
+    command:
+      - "yarn"
+      - "yarn test"
+    plugins:
+      - docker#v3.0.1:
+          image: "node:16"
+          mount-buildkite-agent: false
 
   - label: ":nodejs: 14 :postgres: 11 :jasmine: Postgres Test"
     command:


### PR DESCRIPTION
With Node 16 being the latest version and more and more people installing it, we want to ensure that the IRC bridge works on Node 16.