### PR TITLE
Add dendrite blacklist

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -54,7 +54,7 @@ steps:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Dendrite.Dockerfile.
       - docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile .
       # Run the tests!
-      - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "msc2836" ./tests
+      - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "dendrite_blacklist,msc2836" ./tests
     label: "\U0001F9EA Complement / Dendrite Monolith / :go: 1.15"
     agents:
       queue: "medium"

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
   - command:
       - docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .
       - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
-      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests"
+      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags="dendrite_blacklist" ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
Complement master now has presence tests which fail on Dendrite because we don't do presence yet.