### PR TITLE
Fix syntax error in dendrite/pipeline.yml

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
   - command:
       - docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .
       - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
-      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags="dendrite_blacklist" ./tests"
+      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags=\"dendrite_blacklist\" ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
A small error currently prevents the YAML from parsing.