### PR TITLE
Point towncrier to main branch for Sygnal/Sydent

### DIFF
--- a/sydent/pipeline.yml
+++ b/sydent/pipeline.yml
@@ -3,7 +3,7 @@ steps:
       - "echo '--- Install towncrier'"
       - "pip install towncrier"
       - "echo '+++ Check newsfile'"
-      - "python -m towncrier.check"
+      - "python -m towncrier.check --compare-with='origin/main'"
     label: ":rolled_up_newspaper: Newsfile"
     plugins:
       - docker#v3.0.1:

--- a/sygnal/pipeline.yml
+++ b/sygnal/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - command:
       - "python -m pip install towncrier"
-      - "python -m towncrier.check"
+      - "python -m towncrier.check --compare-with='origin/main'"
     label: "Check Newsfile"
     plugins:
       - docker#v3.0.1:


### PR DESCRIPTION
Since we changed the default branch name, we need to tell towncrier what the new branch name is.