### PR TITLE
Use "npm ci" to install dependencies for IRC bridge

### DIFF
--- a/matrix-appservice-irc/pipeline.yml
+++ b/matrix-appservice-irc/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
   - label: ":eslint: Lint"
     command:
-      - "yarn"
-      - "yarn lint"
+      - "npm ci"
+      - "npm run-script lint"
     plugins:
       - docker#v3.0.1:
           image: "node:14"
@@ -10,8 +10,8 @@ steps:
 
   - label: ":jasmine: Tests Node 12"
     command:
-      - "yarn"
-      - "yarn test"
+      - "npm ci"
+      - "npm run-script test"
     plugins:
       - docker#v3.0.1:
           image: "node:12"
@@ -19,17 +19,17 @@ steps:
 
   - label: ":jasmine: Tests Node 14"
     command:
-      - "yarn"
-      - "yarn test"
+      - "npm ci"
+      - "npm run-script test"
     plugins:
       - docker#v3.0.1:
           image: "node:14"
           mount-buildkite-agent: false
-          
+
   - label: ":jasmine: Tests Node 16"
     command:
-      - "yarn"
-      - "yarn test"
+      - "npm ci"
+      - "npm run-script test"
     plugins:
       - docker#v3.0.1:
           image: "node:16"
@@ -37,8 +37,8 @@ steps:
 
   - label: ":nodejs: 14 :postgres: 11 :jasmine: Postgres Test"
     command:
-      - yarn
-      - yarn ci-test
+      - "npm ci"
+      - "npm run-script ci-test"
     plugins:
       - matrix-org/download#v1.1.0:
           urls:
@@ -50,8 +50,8 @@ steps:
 
   - label: ":nyc: Coverage"
     command:
-      - "yarn"
-      - "yarn ci-test"
+      - "npm ci"
+      - "npm run-script ci-test"
     plugins:
       - docker#v3.0.1:
           image: "node:14"


### PR DESCRIPTION
This has the benefit of ensuring that the lockfile in the repository is
in the correct state as `npm ci` only installs but doesn't update the
lockfile. It is otherwise very simple to miss updating the lockfile when
changing dependencies as (the yarn invocation) would just happily update
the lockfile on every invocation regardless of the state of the lockfile
in the repository.

The two locking mechanisms of NPM and Yarn are not compatible but both
are viable these days. NPM has the benefit of not requiring additional
tooling (besides the node toolchain) and being compatible with
downstream packing tooling (that consumes those lockfiles).

The CI task has so far already spammed something along the lines of:

>  No lockfile found.
> warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.