### PR TITLE
Build Synapse from develop (or same named branch) instead of latest for complement.

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -23,8 +23,13 @@ steps:
           limit: 3
 
   - command:
-      # Build the Synapse for Complement docker image, which is located at:
-      # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
+      # Build a docker image from the same named branch or the latest version of
+      # Synapse, so download it here.
+      - "mkdir -p /synapse"
+      - "(wget -O - https://github.com/matrix-org/synapse/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) | tar -xz --strip-components=1 -C /synapse"
+      - "docker build -t matrixdotorg/synapse:latest -f /synapse/docker/Dockerfile /synapse"
+      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
+      # signing and SSL keys so Synapse can run and federate
       - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
       - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2946,msc3083" ./tests


### PR DESCRIPTION
Currently the Synapse image used is from `synapse:latest` on DockerHub. This makes it annoying to develop a feature and at the same time update the tests in complement.

This is pretty much the same as #157, but from the complement pipeline side