### PR TITLE
Run knocking Complement tests in Synapse and Complement pipelines

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -27,7 +27,7 @@ steps:
       # https://github.com/matrix-org/complement/blob/master/dockerfiles/Synapse.Dockerfile.
       - docker build -t complement-synapse -f dockerfiles/Synapse.Dockerfile dockerfiles/
       # Run the tests!
-      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2946,msc3083" ./tests
+      - COMPLEMENT_BASE_IMAGE=complement-synapse go test -v -tags "synapse_blacklist,msc2403,msc2946,msc3083" ./tests
     label: "\U0001F9EA Complement / Synapse Monolith / :go: 1.15"
     agents:
       queue: "medium"

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -567,7 +567,7 @@ steps:
       - "docker build -t complement-synapse -f /complement/dockerfiles/Synapse.Dockerfile /complement/dockerfiles"
       # Finally, compile and run the tests.
       - "cd /complement"
-      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc2946,msc3083 ./tests"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist,msc2403,msc2946,msc3083 ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"


### PR DESCRIPTION
This PR runs the Complement tests for [MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403) (knocking) on the Synapse and Complement pipelines.

Requires https://github.com/matrix-org/pipelines/pull/158, as we'll need the Complement tests to test against Synapse's `develop` branch (which includes support for knocking).