### PR TITLE
Remove references to complement's `master` branch

### DIFF
--- a/complement/pipeline.yml
+++ b/complement/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/HEAD/dockerfiles/ComplementCIBuildkite.Dockerfile.
           image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI
@@ -56,7 +56,7 @@ steps:
 
   - command:
       # Build the Dendrite for Complement docker image, which is located at:
-      # https://github.com/matrix-org/complement/blob/master/dockerfiles/Dendrite.Dockerfile.
+      # https://github.com/matrix-org/complement/blob/HEAD/dockerfiles/Dendrite.Dockerfile.
       - docker build -t complement-dendrite -f dockerfiles/Dendrite.Dockerfile .
       # Run the tests!
       - COMPLEMENT_BASE_IMAGE=complement-dendrite go test -v -tags "dendrite_blacklist,msc2836" ./tests
@@ -65,7 +65,7 @@ steps:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/HEAD/dockerfiles/ComplementCIBuildkite.Dockerfile.
           image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -38,6 +38,7 @@ steps:
 
   - command:
       - docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .
+      - "mkdir -p complement"
       - "wget -O - https://github.com/matrix-org/complement/archive/HEAD.tar.gz | tar -xz --strip-components=1 -C complement"
       - "cd complement && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags=\"dendrite_blacklist\" ./tests"
     label: "\U0001F9EA Complement"

--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -38,14 +38,14 @@ steps:
 
   - command:
       - docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .
-      - "wget -N https://github.com/matrix-org/complement/archive/master.tar.gz && tar -xzf master.tar.gz"
-      - "cd complement-master && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags=\"dendrite_blacklist\" ./tests"
+      - "wget -O - https://github.com/matrix-org/complement/archive/HEAD.tar.gz | tar -xz --strip-components=1 -C complement"
+      - "cd complement && COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v -tags=\"dendrite_blacklist\" ./tests"
     label: "\U0001F9EA Complement"
     agents:
       queue: "medium"
     plugins:
       - docker#v3.5.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/HEAD/dockerfiles/ComplementCIBuildkite.Dockerfile.
           image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI

--- a/synapse/pipeline.yml
+++ b/synapse/pipeline.yml
@@ -234,8 +234,8 @@ steps:
     plugins:
       - matrix-org/download#v1.1.0:
           urls:
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose.yaml
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose-env
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose.yaml
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose-env
       - docker-compose#v3.7.0:
           run: testenv
           config:
@@ -257,8 +257,8 @@ steps:
     plugins:
       - matrix-org/download#v1.1.0:
           urls:
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose.yaml
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose-env
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose.yaml
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose-env
       - docker-compose#v3.7.0:
           run: testenv
           config:
@@ -514,8 +514,8 @@ steps:
     plugins:
       - matrix-org/download#v1.1.0:
           urls:
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose.yaml
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose-env
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose.yaml
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose-env
       - docker-compose#v3.7.0:
           run: testenv
           config:
@@ -534,8 +534,8 @@ steps:
     plugins:
       - matrix-org/download#v1.1.0:
           urls:
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose.yaml
-            - https://raw.githubusercontent.com/matrix-org/pipelines/master/synapse/docker-compose-env
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose.yaml
+            - https://raw.githubusercontent.com/matrix-org/pipelines/HEAD/synapse/docker-compose-env
       - docker-compose#v3.7.0:
           run: testenv
           config:
@@ -561,7 +561,7 @@ steps:
       # We want to run against complement from the same named branch or the
       # latest version of Complement, so download it here.
       - "mkdir -p /complement"
-      - "(wget -O - https://github.com/matrix-org/complement/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/master.tar.gz) | tar -xz --strip-components=1 -C /complement"
+      - "(wget -O - https://github.com/matrix-org/complement/archive/$BUILDKITE_BRANCH.tar.gz || wget -O - https://github.com/matrix-org/complement/archive/HEAD.tar.gz) | tar -xz --strip-components=1 -C /complement"
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
       # signing and SSL keys so Synapse can run and federate
       - "docker build -t complement-synapse -f /complement/dockerfiles/Synapse.Dockerfile /complement/dockerfiles"
@@ -573,7 +573,7 @@ steps:
       queue: "medium"
     plugins:
       - docker#v3.7.0:
-          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/HEAD/dockerfiles/ComplementCIBuildkite.Dockerfile.
           image: "matrixdotorg/complement:latest"
           mount-buildkite-agent: false
           # Complement needs to know if it is running under CI


### PR DESCRIPTION
I'd like us to consider renaming to `main`, so let's remove the references to `master` specifically.