### PR TITLE
Update Dendrite to Go 1.15

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -2,10 +2,10 @@ steps:
   - command:
       - "env"
       - "bash build.sh"
-    label: "\U0001F528 Build / :go: 1.14"
+    label: "\U0001F528 Build / :go: 1.15"
     plugins:
       - docker#v3.0.1:
-          image: "golang:1.14"
+          image: "golang:1.15"
           mount-buildkite-agent: false
     retry:
       automatic:
@@ -15,10 +15,10 @@ steps:
   - command:
       - "env"
       - "go test ./..."
-    label: "\U0001F9EA Unit tests / :go: 1.14"
+    label: "\U0001F9EA Unit tests / :go: 1.15"
     plugins:
       - docker#v3.0.1:
-          image: "golang:1.14"
+          image: "golang:1.15"
           mount-buildkite-agent: false
 
   - wait
@@ -27,13 +27,13 @@ steps:
       - "env"
       # https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
       - "./build/scripts/find-lint.sh"
-    label: "\U0001F9F9 Lint / :go: 1.14"
+    label: "\U0001F9F9 Lint / :go: 1.15"
     agents:
       # Use a larger instance as linting takes a looot of memory
       queue: "xlarge"
     plugins:
       - docker#v3.0.1:
-          image: "golang:1.14"
+          image: "golang:1.15"
           mount-buildkite-agent: false
 
   - command:
@@ -74,7 +74,7 @@ steps:
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
           
-  - label: "SyTest - :go: 1.14 / :postgres: 9.6"
+  - label: "SyTest - :go: 1.15 / :postgres: 9.6"
     agents:
       queue: "medium"
     env:
@@ -105,7 +105,7 @@ steps:
         - exit_status: 2
           limit: 2
   
-  - label: "SyTest - :go: 1.14 / :postgres: 9.6 / full HTTP APIs"
+  - label: "SyTest - :go: 1.15 / :postgres: 9.6 / full HTTP APIs"
     agents:
       queue: "medium"
     env:
@@ -137,7 +137,7 @@ steps:
         - exit_status: 2
           limit: 2
 
-  - label: "SyTest - :go: 1.14 / :sqlite: 3"
+  - label: "SyTest - :go: 1.15 / :sqlite: 3"
     agents:
       queue: "medium"
     command:
@@ -166,7 +166,7 @@ steps:
         - exit_status: 2
           limit: 2
 
-  - label: "SyTest - :go: 1.14 / :sqlite: 3 / full HTTP APIs"
+  - label: "SyTest - :go: 1.15 / :sqlite: 3 / full HTTP APIs"
     agents:
       queue: "medium"
     env:


### PR DESCRIPTION
This updates the build and lint steps in the dendrite pipeline to Go 1.15.

matrix-org/sytest@580207b updated the Sytest image already.