### PR TITLE
Remove steps now handled by GitHub actions

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -4,32 +4,6 @@
 # We propagate the environment to the container (sse https://github.com/buildkite-plugins/docker-buildkite-plugin#propagate-environment-optional-boolean)
 
 steps:
-  - label: "Compile and run Unit tests"
-    agents:
-      # We use a xlarge sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      queue: "xlarge"
-    commands:
-      - "./gradlew clean test --stacktrace -PallWarningsAsErrors=false"
-    plugins:
-      - docker#v3.1.0:
-          image: "runmymind/docker-android-sdk"
-          propagate-environment: true
-          mount-buildkite-agent: false
-
-  - label: "Compile Android tests"
-    agents:
-      # We use a xlarge sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      queue: "xlarge"
-    commands:
-      - "./gradlew clean assembleAndroidTest --stacktrace -PallWarningsAsErrors=false"
-    plugins:
-      - docker#v3.1.0:
-          image: "runmymind/docker-android-sdk"
-          propagate-environment: true
-          mount-buildkite-agent: false
-
   - label: ":android: Assemble GPlay Debug version"
     agents:
       # We use a xlarge sized instance instead of the normal small ones because
@@ -42,23 +16,6 @@ steps:
     key: "gplay_debug"
     artifact_paths:
       - "*.apk"
-    branches: "!main"
-    plugins:
-      - docker#v3.1.0:
-          image: "runmymind/docker-android-sdk"
-          propagate-environment: true
-          mount-buildkite-agent: false
-
-  - label: ":android: GPlay lint"
-    agents:
-      # We use a xlarge sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      # build on the burn-after-use ephemeral queue
-      queue: "ephemeral-xlarge"
-    commands:
-      - "./gradlew clean lintGplayRelease --stacktrace"
-    artifact_paths:
-      - "vector/build/reports/*.*"
     branches: "!main"
     plugins:
       - docker#v3.1.0:
@@ -84,39 +41,6 @@ steps:
           propagate-environment: true
           mount-buildkite-agent: false
 
-  - label: ":android: FDroid lint"
-    agents:
-      # We use a xlarge sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      # build on the burn-after-use ephemeral queue
-      queue: "ephemeral-xlarge"
-    commands:
-      - "./gradlew clean lintFdroidRelease --stacktrace"
-    artifact_paths:
-      - "vector/build/reports/*.*"
-    branches: "!main"
-    plugins:
-      - docker#v3.1.0:
-          image: "runmymind/docker-android-sdk"
-          propagate-environment: true
-          mount-buildkite-agent: false
-
-  - label: ":android: Lint analysis of the SDK"
-    agents:
-      # We use a xlarge sized instance instead of the normal small ones because
-      # gradle build can be memory hungry
-      queue: "xlarge"
-    commands:
-      - "./gradlew clean :matrix-sdk-android:lintRelease --stacktrace"
-    artifact_paths:
-      - "matrix-sdk-android/build/reports/*.*"
-    branches: "!main"
-    plugins:
-      - docker#v3.1.0:
-          image: "runmymind/docker-android-sdk"
-          propagate-environment: true
-          mount-buildkite-agent: false
-
   - label: ":android: Build Google Play unsigned release APK"
     agents:
       # We use a xlarge sized instance instead of the normal small ones because
@@ -134,41 +58,6 @@ steps:
           image: "runmymind/docker-android-sdk"
           propagate-environment: true
           mount-buildkite-agent: false
-
-  # Code quality
-  - label: ":lint-roller: Code quality"
-    command:
-      - apt-get update
-      - DEBIAN_FRONTEND=noninteractive apt-get install -y wget perl-modules
-      - ./tools/check/check_code_quality.sh
-    plugins:
-      - docker#v3.1.0:
-          image: "debian:buster-slim"
-          mount-buildkite-agent: false
-
-  - label: "ktlint"
-    command:
-      - "curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.36.0/ktlint && chmod a+x ktlint"
-      - "./ktlint --android --experimental -v"
-    plugins:
-      - docker#v3.1.0:
-          image: "openjdk"
-          mount-buildkite-agent: false
-
-  # Check that some language files are identical.
-  # Due to Android issue, some of the resource folders, used at runtime, do not have the same name than those used by Weblate export
-  # - Indonesian:
-  # must be values-in/, and Weblate export data into values-id/
-  # In case of diff, copy values-id/strings.xml to values-in/strings.xml
-  # - Hebrew:
-  # must be values-iw/, and Weblate export data into values-he/
-  # In case of diff, copy values-he/strings.xml to values-iw/strings.xml
-  #
-  # Note that this step will fail for the first diff encountered, we may improve this in the future.
-  # - label: "Weblate export check"
-  #   command:
-  #     - "diff ./vector/src/main/res/values-id/strings.xml ./vector/src/main/res/values-in/strings.xml"
-  #     - "diff ./vector/src/main/res/values-he/strings.xml ./vector/src/main/res/values-iw/strings.xml"
 
   # run the εxodus static analyser
   - label: "εxodus"


### PR DESCRIPTION
Keep only the APK generation for now, and the εxodus check.