### PR TITLE
Swap out js sdk release-mode script for js script

### DIFF
--- a/matrix-react-sdk/pipeline.yaml
+++ b/matrix-react-sdk/pipeline.yaml
@@ -18,7 +18,11 @@ steps:
       - "echo '+++ Lint'"
       - "yarn lint:types"
       - "echo '--- Switch js-sdk to release mode'"
-      - "./scripts/ci/js-sdk-to-release.sh"
+      - "./scripts/ci/js-sdk-to-release.js"
+      - "pushd node_modules/matrix-js-sdk"
+      - "yarn run build:compile"
+      - "yarn run build:types"
+      - "popd"
       - "echo '+++ Lint (release mode)'"
       - "yarn lint:types"
     plugins:


### PR DESCRIPTION
The buildkite builders don't have jq so this never worked.
Just make it a js script instead.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/6759