### PR TITLE
Update rageshake build to use golang v1.16 / v1.17.

### DIFF
--- a/rageshake/pipeline.yml
+++ b/rageshake/pipeline.yml
@@ -12,14 +12,7 @@ steps:
     command: ".buildkite/lint.sh"
     plugins:
       - docker#v3.0.1:
-          image: "golang:1.15"
-          mount-buildkite-agent: false
-          
-  - label: ":hammer: Build / :go: 1.15"
-    command: ".buildkite/build-and-test.sh"
-    plugins:
-      - docker#v3.0.1:
-          image: "golang:1.15"
+          image: "golang:1.16"
           mount-buildkite-agent: false
           
   - label: ":hammer: Build / :go: 1.16"
@@ -27,4 +20,11 @@ steps:
     plugins:
       - docker#v3.0.1:
           image: "golang:1.16"
+          mount-buildkite-agent: false
+          
+  - label: ":hammer: Build / :go: 1.17"
+    command: ".buildkite/build-and-test.sh"
+    plugins:
+      - docker#v3.0.1:
+          image: "golang:1.17"
           mount-buildkite-agent: false


### PR DESCRIPTION
These are the current stable builds, and the lint step does
not seem to pass with go v1.15.

https://buildkite.com/matrix-dot-org/rageshake/builds/42#000a370f-9c12-427a-b3ae-2ef14bec30be for an example of the failure; local testing shows that running the linter using go v1.15 fails with the same error; 1.16/1.17 are fine.

Assuming it's just backwards incompatibility on go's front here.