### PR TITLE
Propagate environment variables for Windows build

### DIFF
--- a/dendrite/pipeline.yml
+++ b/dendrite/pipeline.yml
@@ -25,6 +25,7 @@ steps:
       - docker#v3.0.1:
           image: "golang:1.15"
           mount-buildkite-agent: false
+          propagate-environment: true
     retry:
       automatic:
         - exit_status: 128


### PR DESCRIPTION
The last runs didn't create Windows binaries, since the environment wasn't used.