### PR TITLE
Exodus changed their docker entrypoint in a minor release.

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -70,7 +70,7 @@ steps:
 
     commands:
       - "mv vector-gplay-universal-*.apk app.apk"
-      - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone -j > exodus.json"
+      - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone:latest -j /apk.app > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
     depends_on: 
       - gplay_debug


### PR DESCRIPTION
Previously the entrypoint included app.apk; now the entrypoint is just the script, and the APK is passed via the CMD.

The `-j` flag we passed is overwriting the CMD - so we need to add the app.apk back in to let the changed docker container work.

Fixes the build being broken in vector-im/element-android#5422 (but a TODO is still to migrate to GHA)
