### PR TITLE
Fixing android exodus usage

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -70,7 +70,7 @@ steps:
 
     commands:
       - "mv vector-gplay-universal-*.apk app.apk"
-      - "docker run -v $(pwd):/app.apk --rm -i exodusprivacy/exodus-standalone /app/app.apk -j > exodus.json"
+      - "docker run -v $(pwd):/app --rm -i exodusprivacy/exodus-standalone /app/app.apk -j > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
     depends_on: 
       - gplay_debug

--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -70,7 +70,7 @@ steps:
 
     commands:
       - "mv vector-gplay-universal-*.apk app.apk"
-      - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone -j > exodus.json"
+      - "docker run -v $(pwd):/app.apk --rm -i exodusprivacy/exodus-standalone /app/app.apk -j > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
     depends_on: 
       - gplay_debug


### PR DESCRIPTION
The latest version of exodus (which automatically gets pulled in) updates the docker entry points, breaking our existing usage

- Fixed by splitting the directory from the apk and providing the apk as a dedicated param

*running locally 

| BEFORE | AFTER |
| --- | --- |
| ![2022-03-04T11:10:39,717996680+00:00](https://user-images.githubusercontent.com/1848238/156754512-e80c75ff-9779-44b8-92a5-37228128ad1a.png)|![2022-03-04T11:22:57,274156579+00:00](https://user-images.githubusercontent.com/1848238/156754813-336e7903-af2d-44c5-bd6b-4d0ca60b8561.png)

Their readme was also updated to reflect the change https://github.com/Exodus-Privacy/exodus-standalone/blob/master/README.md#using-docker
