### PR TITLE
Typo in docker command

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -70,7 +70,7 @@ steps:
 
     commands:
       - "mv vector-gplay-universal-*.apk app.apk"
-      - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone:latest -j /apk.app > exodus.json"
+      - "docker run -v $(pwd)/app.apk:/app.apk --rm -i exodusprivacy/exodus-standalone:latest -j /app.apk > exodus.json"
       - "jq -e '.trackers == []' exodus.json > /dev/null || { echo 'static analysis identified user tracking library' ; false; }"
     depends_on: 
       - gplay_debug


### PR DESCRIPTION
Getting apk.app and app.apk the wrong way around.

Worked fine when I tested it locally; just got my apk and app mixed up.