### PR TITLE
Update the android build pipeline to include new artifact location

### DIFF
--- a/element-android/pipeline.yml
+++ b/element-android/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       queue: "ephemeral-xlarge"
     commands:
       - "./gradlew clean assembleGplayDebug --stacktrace"
-      - "mv vector/build/outputs/apk/gplay/debug/*.apk ."
+      - "mv vector-app/build/outputs/apk/gplay/debug/*.apk ."
     key: "gplay_debug"
     artifact_paths:
       - "*.apk"
@@ -31,7 +31,7 @@ steps:
       queue: "ephemeral-xlarge"
     commands:
       - "./gradlew clean assembleFdroidDebug --stacktrace"
-      - "mv vector/build/outputs/apk/fdroid/debug/*.apk ."
+      - "mv vector-app/build/outputs/apk/fdroid/debug/*.apk ."
     artifact_paths:
       - "*.apk"
     branches: "!main"
@@ -48,7 +48,7 @@ steps:
       queue: "xlarge"
     commands:
       - "./gradlew clean assembleGplayRelease --stacktrace"
-      - "mv vector/build/outputs/apk/gplay/release/*.apk ."
+      - "mv vector-app/build/outputs/apk/gplay/release/*.apk ."
     key: "gplay_release"
     artifact_paths:
       - "*.apk"


### PR DESCRIPTION
https://github.com/vector-im/element-android/pull/6720 introduces a new top level `vector-app` module, updating `vector` to a library 

Output artifacts will be created in `vector-app/build/outputs`

**Should be merged with https://github.com/vector-im/element-android/pull/6720**